### PR TITLE
Remove old genclassification

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1,9 +1,9 @@
 ### Struct and different Power System constructors depending on the data provided ####
 
-struct PowerSystem{L <: ElectricLoad,
-                   T <: Union{Nothing,Array{ <: Thermal,1}},
-                   R <: Union{Nothing,Array{ <: Renewable,1}},     
-                   H <: Union{Nothing,Array{ <: Hydro,1}},
+struct PowerSystem{T <: Union{Nothing,Array{ <: ThermalGen,1}},
+                   R <: Union{Nothing,Array{ <: RenewableGen,1}},     
+                   H <: Union{Nothing,Array{ <: HydroGen,1}},
+                   L <: ElectricLoad,
                    B <: Union{Nothing,Array{ <: Branch,1}},
                    S <: Union{Nothing,Array{ <: Storage,1}}
                    }
@@ -26,7 +26,7 @@ struct PowerSystem{L <: ElectricLoad,
         time_length = timeseriescheckload(loads)
         !isa(sources.renewable, Nothing) ? timeserieschecksources(sources.renewable, time_length) : true
         !isa(sources.hydro, Nothing) ? timeserieschecksources(sources.hydro, time_length) : true
-        new{L, Nothing, Nothing}(buses,
+        new{Union{Nothing,Array{ <: ThermalGen,1}}, Union{Nothing,Array{ <: RenewableGen,1}}, Union{Nothing,Array{ <: HydroGen,1}}, L, Nothing, Nothing}(buses,
                         sources,
                         loads,
                         nothing,
@@ -55,7 +55,7 @@ struct PowerSystem{L <: ElectricLoad,
         checkanglelimits!(branches)
         #timeserieschecksources(sources.hydro, time_length)
 
-        new{L, B, Nothing}(buses,
+        new{Union{Nothing,Array{ <: ThermalGen,1}}, Union{Nothing,Array{ <: RenewableGen,1}}, Union{Nothing,Array{ <: HydroGen,1}}, L, B, Nothing}(buses,
                 sources,
                 loads,
                 branches,
@@ -78,7 +78,7 @@ struct PowerSystem{L <: ElectricLoad,
         !isa(sources.renewable, Nothing) ? timeserieschecksources(sources.renewable, time_length) : true
         !isa(sources.hydro, Nothing) ? timeserieschecksources(sources.hydro, time_length) : true
 
-        new{L, Nothing, S}(buses,
+        new{Union{Nothing,Array{ <: ThermalGen,1}}, Union{Nothing,Array{ <: RenewableGen,1}}, Union{Nothing,Array{ <: HydroGen,1}}, L, Nothing, S}(buses,
                 sources,
                 loads,
                 nothing,
@@ -106,7 +106,7 @@ struct PowerSystem{L <: ElectricLoad,
         !isa(sources.renewable, Nothing) ? timeserieschecksources(sources.renewable, time_length) : true
         !isa(sources.hydro, Nothing) ? timeserieschecksources(sources.hydro, time_length) : true
 
-        new{L, B, S}(buses,
+        new{Union{Nothing,Array{ <: ThermalGen,1}}, Union{Nothing,Array{ <: RenewableGen,1}}, Union{Nothing,Array{ <: HydroGen,1}}, L, B, S}(buses,
                 sources,
                 loads,
                 branches,

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,10 +1,14 @@
 ### Struct and different Power System constructors depending on the data provided ####
 
 struct PowerSystem{L <: ElectricLoad,
+                   T <: Union{Nothing,Array{ <: Thermal,1}},
+                   R <: Union{Nothing,Array{ <: Renewable,1}},     
+                   H <: Union{Nothing,Array{ <: Hydro,1}},
                    B <: Union{Nothing,Array{ <: Branch,1}},
-                   S <: Union{Nothing,Array{ <: Storage,1}}}
+                   S <: Union{Nothing,Array{ <: Storage,1}}
+                   }
     buses::Array{Bus,1}
-    generators::Sources
+    generators::NamedTuple{(:thermal, :renewable, :hydro), Tuple{T, R, H}}
     loads::Array{L,1}
     branches::B
     storage::S
@@ -22,7 +26,7 @@ struct PowerSystem{L <: ElectricLoad,
         time_length = timeseriescheckload(loads)
         !isa(sources.renewable, Nothing) ? timeserieschecksources(sources.renewable, time_length) : true
         !isa(sources.hydro, Nothing) ? timeserieschecksources(sources.hydro, time_length) : true
-        new{L, Nothing, Nothing,}(buses,
+        new{L, Nothing, Nothing}(buses,
                         sources,
                         loads,
                         nothing,

--- a/src/models/generation.jl
+++ b/src/models/generation.jl
@@ -26,7 +26,7 @@ function genclassifier(gen::Array{T}) where T <: Generator
     isempty(r) ? r = nothing : r
     isempty(h) ? h = nothing : h
 
-    generators = (thermal = t, renewables =r, hydro = h)
+    generators = (thermal = t, renewable =r, hydro = h)
 
     return generators
 end

--- a/src/models/generation.jl
+++ b/src/models/generation.jl
@@ -6,12 +6,13 @@ include("generation/renewable_generation.jl")
 include("generation/thermal_generation.jl")
 include("generation/hydro_generation.jl")
 
-#Sources shouldn't be exported. It is used internally to classify the generators.
+#=
 struct Sources{T <: Union{Nothing,Array{<:ThermalGen,1}}, R <: Union{Nothing,Array{<:RenewableGen,1}}, H <: Union{Nothing,Array{<:HydroGen,1}}}
     thermal::T
     renewable::R
     hydro::H
 end
+=#
 
 # Generator Classifier
 function genclassifier(gen::Array{T}) where T <: Generator
@@ -25,7 +26,8 @@ function genclassifier(gen::Array{T}) where T <: Generator
     isempty(r) ? r = nothing : r
     isempty(h) ? h = nothing : h
 
-    generators = Sources(t,r,h)
+    generators = (thermal = t, renewables =r, hydro = h)
 
     return generators
 end
+


### PR DESCRIPTION
With this PR we get rid of the old sources struct and implement the classifier as originally designed using Named Tuples