### PR TITLE
Ts scaling

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -132,3 +132,12 @@ function PowerSystem(ps_dict::Dict{String,Any})
         sys = PowerSystem(Buses, Generators,Loads,Branches,Storage,ps_dict["baseMVA"]);
         return sys
 end
+
+function PowerSystem(file::String, ts_folder::String; kwargs...)
+
+        ps_dict = parsestandardfiles(file,ts_folder; kwargs...)
+        Buses, Generators, Storage, Branches, Loads, LoadZones ,Shunts = ps_dict2ps_struct(ps_dict)
+        sys = PowerSystem(Buses, Generators,Loads,Branches,Storage,ps_dict["baseMVA"]);
+
+        return sys
+end

--- a/src/parsers/dict_to_struct.jl
+++ b/src/parsers/dict_to_struct.jl
@@ -140,7 +140,13 @@ function add_time_series(Device_dict::Dict{String,Any}, df::DataFrames.DataFrame
     for (device_key,device) in Device_dict
         if device_key in map(String, names(df))
             ts_raw = df[Symbol(device_key)]
-            Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw)
+            if maximum(ts_raw) <= 1.0
+                @info "assumed time series is a scaling factor for $device_key"
+                Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw)
+            else
+                @info "assumed time series is MW for $device_key"
+                Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw/device.tech.installedcapacity)
+            end
         end
     end
     return Device_dict

--- a/src/parsers/dict_to_struct.jl
+++ b/src/parsers/dict_to_struct.jl
@@ -145,7 +145,7 @@ function add_time_series(Device_dict::Dict{String,Any}, df::DataFrames.DataFrame
                 Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw)
             else
                 @info "assumed time series is MW for $device_key"
-                Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw/device.tech.installedcapacity)
+                Device_dict[device_key]["scalingfactor"] = TimeSeries.TimeArray(df[:DateTime],ts_raw/device["tech"]["installedcapacity"])
             end
         end
     end

--- a/src/utils/base_checks.jl
+++ b/src/utils/base_checks.jl
@@ -6,3 +6,34 @@ function orderedlimits(limits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float
     end
     return limits
 end
+
+
+function getresolution(ts::TimeSeries.TimeArray)
+
+    tstamps = timestamp(ts)
+    timediffs = unique([tstamps[ix]-tstamps[ix-1] for ix in 2:length(tstamps)])
+
+    res = []
+
+    for timediff in timediffs
+        if mod(timediff,Millisecond(Day(1))) == Millisecond(0) 
+            push!(res,Day(timediff/Millisecond(Day(1))))
+        elseif mod(timediff,Millisecond(Hour(1))) == Millisecond(0)
+            push!(res,Hour(timediff/Millisecond(Hour(1))))
+        elseif mod(timediff,Millisecond(Minute(1))) == Millisecond(0)
+            push!(res,Minute(timediff/Millisecond(Minute(1))))
+        elseif mod(timediff,Millisecond(Second(1))) == Millisecond(0)
+            push!(res,Second(timediff/Millisecond(Second(1))))
+        else
+            @error "I can't understand the resolution of the timeseries"
+        end
+    end
+
+    if length(res) > 1
+        @warn "Timeseries has non-uniform resolution: this is currently not supported"
+    else
+        resolution = res[1]
+    end
+    
+    return resolution
+end

--- a/test/checks_testing.jl
+++ b/test/checks_testing.jl
@@ -17,3 +17,7 @@ branches5 = [Line("1", true,  (from=nodes5[1],to=nodes5[2]), 0.00281, 0.0281,  (
 @test try @assert (branches5[3].anglelimits) == (min = -75.0,max = 90.0); true finally end
 @test try @assert (branches5[4].anglelimits) == (min = -90.0,max = 90.0); true finally end
 
+@test try @assert PowerSystems.getresolution(TimeArray([DateTime(today())+Minute(i*2) for i in 1:5],ones(5)))==Minute(2); true finally end
+@test try @assert PowerSystems.getresolution(TimeArray([DateTime(today())+Day(i) for i in 1:5],ones(5)))==Day(1); true finally end
+@test try @assert PowerSystems.getresolution(TimeArray([DateTime(today())+Second(i) for i in 1:5],ones(5)))==Second(1); true finally end
+@test try @assert PowerSystems.getresolution(TimeArray([DateTime(today())+Hour(i) for i in 1:5],ones(5)))==Hour(1); true finally end


### PR DESCRIPTION
this PR:
 - adds a shortcut PowerSystem() constructor that takes paths to a load flow case, and a time series directory to create a PowerSystem
 - adds a `getresolution()` function that returns the time resolution of a `TimeArray`