### PR TITLE
Docstrings

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -1,5 +1,8 @@
 isdefined(Base, :__precompile__) && __precompile__()
 
+"""
+Module for constructing self-contained power system objects.
+"""
 module PowerSystems
 
 #################################################################################

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,9 +1,39 @@
 ### Struct and different Power System constructors depending on the data provided ####
 
+"""
+    PowerSystem
+
+A power system defined by fields for buses, generators, loads, branches, and
+overall system parameters.
+
+# Constructor
+```julia
+PowerSystem(buses, generators, loads, branches, storage, basepower; kwargs...)
+```
+
+# Arguments
+
+* `buses`::Array{Bus,1} : an array of buses
+* `generators`::Array{Generator,1} : an array of generators of (possibly) different types
+* `loads`::Array{ElectricLoad,1} : an array of load specifications that includes timing of the loads
+* `branches`::Array{Branch,1} : an array of branches; may be `nothing`
+* `storage`::Array{Storage,1} : an array of storage devices; may be `nothing`
+* `basepower`::Float64 : the base power of the system (is this true?)
+
+# Keyword arguments
+
+* `runchecks`::Bool : run available checks on input fields
+(any other keyword arguments?)
+
+"""
 struct PowerSystem{L <: ElectricLoad,
                    B <: Union{Nothing,Array{ <: Branch,1}},
                    S <: Union{Nothing,Array{ <: Storage,1}}
                    }
+    # docs for PowerSystem fields are currently not working, JJS 1/15/19
+    """
+    testing doc for time_periods field
+    """
     buses::Array{Bus,1}
     generators::GenClasses
     loads::Array{L,1}

--- a/src/base.jl
+++ b/src/base.jl
@@ -9,6 +9,8 @@ overall system parameters.
 # Constructor
 ```julia
 PowerSystem(buses, generators, loads, branches, storage, basepower; kwargs...)
+PowerSystem(ps_dict; kwargs...)
+PowerSystem(file, ts_folder; kwargs...)
 ```
 
 # Arguments
@@ -18,21 +20,23 @@ PowerSystem(buses, generators, loads, branches, storage, basepower; kwargs...)
 * `loads`::Array{ElectricLoad,1} : an array of load specifications that includes timing of the loads
 * `branches`::Array{Branch,1} : an array of branches; may be `nothing`
 * `storage`::Array{Storage,1} : an array of storage devices; may be `nothing`
-* `basepower`::Float64 : the base power of the system (is this true?)
+* `basepower`::Float64 : the base power of the system (DOCTODO: is this true? what are the units of base power?)
+* `ps_dict`::Dict{String,Any} : the dictionary object containing PowerSystem data
+* `file`::String, `ts_folder`::String : the filename and foldername that contain the PowerSystem data
 
 # Keyword arguments
 
 * `runchecks`::Bool : run available checks on input fields
-(any other keyword arguments?)
+DOCTODO: any other keyword arguments?
 
 """
 struct PowerSystem{L <: ElectricLoad,
                    B <: Union{Nothing,Array{ <: Branch,1}},
                    S <: Union{Nothing,Array{ <: Storage,1}}
                    }
-    # docs for PowerSystem fields are currently not working, JJS 1/15/19
+    # DOCTODO docs for PowerSystem fields are currently not working, JJS 1/15/19
     """
-    testing doc for time_periods field
+    docstrings for buses field
     """
     buses::Array{Bus,1}
     generators::GenClasses
@@ -163,6 +167,10 @@ struct PowerSystem{L <: ElectricLoad,
 
 end
 
+# DOCTODO JJS What is the purpose of this statement? OK, it looks like a
+# constructor to allow the arguments to be made as keyword arguments, with
+# defaults for those that are not provided. If so, this should be added to list
+# of constructors in the docstring above
 PowerSystem(; buses = [Bus()],
             generators = [ThermalDispatch(), RenewableFix()],
             loads = [ PowerLoad()],

--- a/src/models/generation/tech_common.jl
+++ b/src/models/generation/tech_common.jl
@@ -1,10 +1,17 @@
+# DOCTODO  add docstring for TechRenewable
 struct TechRenewable <: TechnicalParams
     installedcapacity::Float64 # [MW]
     reactivepowerlimits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float64}},Nothing} # [MVar]
     powerfactor::Union{Float64,Nothing} # [-1. -1]
 end
 
-TechRenewable(; InstalledCapacity = 0, reactivepowerlimits = nothing, powerfactor = nothing) = TechRenewable(InstalledCapacity, reactivepowerlimits, powerfactor)
+# DOCTODO document this constructor for TechRenewable
+TechRenewable(; InstalledCapacity = 0,
+                reactivepowerlimits = nothing,
+                powerfactor = nothing
+              ) = TechRenewable(InstalledCapacity, reactivepowerlimits,
+                                powerfactor)
+
 
 """
     TechThermal(activepower::Float64,
@@ -16,26 +23,21 @@ TechRenewable(; InstalledCapacity = 0, reactivepowerlimits = nothing, powerfacto
 
 Data Structure for the economical parameters of thermal generation technologies.
     The data structure can be called calling all the fields directly or using named fields.
-    Two examples are provided one with minimal data definition and a more comprenhensive one
+    Two examples [DOCTODO only one example exists below] are provided one with minimal data definition and a more comprenhensive one
 
     # Examples
 
     ```jldoctest
 
     julia> Tech = TechThermal(activepower = 100.0, activepowerlimits = (min = 50.0, max = 200.0))
-    WARNING: Limits defined as nothing
-    Tech Gen:
-        Real Power: 100.0
-        Real Power Limits: (min = 50.0, max = 200.0)
-        Reactive Power: nothing
-        Reactive Power Limits: nothing
-        Ramp Limits: nothing
-        Time Limits: nothing
-
-
-
-
-
+   [ Info: 'Reactive Power' limits defined as nothing
+    TechThermal:
+       activepower: 100.0
+       activepowerlimits: (min = 50.0, max = 200.0)
+       reactivepower: nothing
+       reactivepowerlimits: nothing
+       ramplimits: nothing
+       timelimits: nothing
 
 """
 struct TechThermal <: TechnicalParams
@@ -52,10 +54,12 @@ struct TechThermal <: TechnicalParams
     end
 end
 
+# DOCTODO document this constructor 
 TechThermal(; activepower = 0.0,
-          activepowerlimits = (min = 0.0, max = 0.0),
-          reactivepower = nothing,
-          reactivepowerlimits = nothing,
-          ramplimits = nothing,
-          timelimits = nothing
-        ) = TechThermal(activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits)
+            activepowerlimits = (min = 0.0, max = 0.0),
+            reactivepower = nothing,
+            reactivepowerlimits = nothing,
+            ramplimits = nothing,
+            timelimits = nothing
+            ) = TechThermal(activepower, activepowerlimits, reactivepower,
+                            reactivepowerlimits, ramplimits, timelimits)

--- a/src/models/topological_elements.jl
+++ b/src/models/topological_elements.jl
@@ -13,8 +13,8 @@ Bus(number, name, bustype, angle, voltage, voltagelimits, basevoltage)
 * `name`::String : the name of the bus
 * `bustype`::String : type of bus, [PV, PQ, SF]; may be `nothing`
 * `angle`::Float64 : angle of the bus in degrees; may be `nothing`
-* `voltage`::Float64 : (not sure what this means) [pu]; may be `nothing`
-* `voltagelimits`::NamedTuple(min::Float64, max::Float64) : limits on the voltage variation; may be `nothing`
+* `voltage`::Float64 : voltage as a multiple of basevoltage; may be `nothing`
+* `voltagelimits`::NamedTuple(min::Float64, max::Float64) : limits on the voltage variation as multiples of basevoltage; may be `nothing`
 * `basevoltage`::Float64 : the base voltage in kV; may be `nothing`
 
 """
@@ -28,16 +28,18 @@ struct Bus <: PowerSystemDevice
     bustype::Union{String,Nothing} # [PV, PQ, SF]
     """ angle of the bus in degrees """
     angle::Union{Float64,Nothing} # [degrees]
-    """ is this a multiple of the base voltage? [pu] """
+    """ voltage as a multiple of basevoltage """
     voltage::Union{Float64,Nothing} # [pu]
-    """ limits on the voltage variation """
-    voltagelimits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float64}},Nothing} # [pu]
+    """ limits on the voltage variation as multiples of basevoltage """
+    voltagelimits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float64}},
+                         Nothing} # [pu]
     """
     the base voltage in kV
     """
     basevoltage::Union{Float64,Nothing} # [kV]
 end
 
+# DOCTODO  add this constructor type to docstring for Bus
 Bus(;   number = 0,
         name = "init",
         bustype = nothing,
@@ -45,9 +47,10 @@ Bus(;   number = 0,
         voltage = 0.0,
         voltagelimits = (min = 0.0, max = 0.0),
         basevoltage = nothing
-    ) = Bus(number, name, bustype, angle, voltage, orderedlimits(voltagelimits, "Voltage"), basevoltage)
+    ) = Bus(number, name, bustype, angle, voltage,
+            orderedlimits(voltagelimits, "Voltage"), basevoltage)
 
-
+# DOCTODO What are LoadZones? JJS 1/18/19
 struct LoadZones  <: PowerSystemDevice
     number::Int
     name::String

--- a/src/models/topological_elements.jl
+++ b/src/models/topological_elements.jl
@@ -1,10 +1,40 @@
+"""
+    Bus
+
+A power-system bus. 
+
+# Constructor
+```julia
+Bus(number, name, bustype, angle, voltage, voltagelimits, basevoltage)
+```
+
+# Arguments
+* `number`::Int64 : number associated with the bus
+* `name`::String : the name of the bus
+* `bustype`::String : type of bus, [PV, PQ, SF]; may be `nothing`
+* `angle`::Float64 : angle of the bus in degrees; may be `nothing`
+* `voltage`::Float64 : (not sure what this means) [pu]; may be `nothing`
+* `voltagelimits`::NamedTuple(min::Float64, max::Float64) : limits on the voltage variation; may be `nothing`
+* `basevoltage`::Float64 : the base voltage in kV; may be `nothing`
+
+"""
 struct Bus <: PowerSystemDevice
+    # field docstrings work here! (they are not for PowerSystem)
+    """ number associated with the bus """
     number::Int64
+    """ the name of the bus """
     name::String
+    """ bus type, [PV, PQ, SF] """
     bustype::Union{String,Nothing} # [PV, PQ, SF]
+    """ angle of the bus in degrees """
     angle::Union{Float64,Nothing} # [degrees]
+    """ is this a multiple of the base voltage? [pu] """
     voltage::Union{Float64,Nothing} # [pu]
+    """ limits on the voltage variation """
     voltagelimits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float64}},Nothing} # [pu]
+    """
+    the base voltage in kV
+    """
     basevoltage::Union{Float64,Nothing} # [kV]
 end
 


### PR DESCRIPTION
Some work on docstrings for PowerSystems (the module), the PowerSystem struct,  and structs in topological_elements, and tech_common. 
@jd-lara suggested merging and then continue adding/revising docstrings as we work on other tasks. I used the keyword `DOCTODO` to bring attention to docstring items to address.