### PR TITLE
Add download test data function

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,21 +1,5 @@
 
-const POWERSYSTEMSTESTDATA_GITHUB_URL = "https://github.com/NREL/PowerSystemsTestData.git"
+include(joinpath(@__DIR__, "../src/utils/data.jl"))
+using .UtilsData
 
-base_dir = string(dirname(dirname(@__FILE__)))
-const DATA_FOLDER = joinpath(base_dir,"data")
-
-const CLONE_CMD = `git clone --depth 1 $POWERSYSTEMSTESTDATA_GITHUB_URL $DATA_FOLDER`
-
-const PULL_CMD = `git -C $DATA_FOLDER pull`
-
-function download_data()
-
-    if !isdir(DATA_FOLDER)
-        run(CLONE_CMD)
-    else
-        run(PULL_CMD)
-    end
-
-end
-
-download_data()
+download(TestData)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,5 @@
 
 include(joinpath(@__DIR__, "../src/utils/data.jl"))
-using .UtilsData
+import .UtilsData: TestData
 
 download(TestData)

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -134,4 +134,8 @@ include("base.jl")
 include("utils/print.jl")
 include("utils/lodf_calculations.jl")
 
+# Download test data
+include("utils/data.jl")
+using .UtilsData
+
 end # module

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -136,6 +136,6 @@ include("utils/lodf_calculations.jl")
 
 # Download test data
 include("utils/data.jl")
-using .UtilsData
+import .UtilsData: TestData
 
 end # module

--- a/src/utils/data.jl
+++ b/src/utils/data.jl
@@ -1,0 +1,58 @@
+# this file is included in the build.jl script
+
+module UtilsData
+
+    __precompile__(true)
+
+    export TestData
+
+    abstract type AbstractOS end
+    abstract type Unix <: AbstractOS end
+    abstract type BSD <: Unix end
+
+    abstract type Windows <: AbstractOS end
+    abstract type MacOS <: BSD end
+    abstract type Linux <: BSD end
+
+    if Sys.iswindows()
+        const os = Windows
+    elseif Sys.isapple()
+        const os = MacOS
+    else
+        const os = Linux
+    end
+
+    abstract type TestData end
+
+    if Sys.iswindows()
+        const POWERSYSTEMSTESTDATA_URL = "https://github.com/NREL/PowerSystemsTestData/archive/master.zip"
+    else
+        const POWERSYSTEMSTESTDATA_URL = "https://github.com/NREL/PowerSystemsTestData/archive/master.tar.gz"
+    end
+
+    """
+    Download Power System Data into a "data" folder in given argument path.
+    Defaults to the root of the PowerSystems package.
+
+    Returns the downloaded folder name.
+    """
+    function Base.download(::Type{TestData}, folder::AbstractString=joinpath(@__DIR__, "../..") |> abspath)
+        tempfilename = Base.download(POWERSYSTEMSTESTDATA_URL)
+        directory = folder |> normpath |> abspath
+        mkpath(directory)
+        unzip(os, tempfilename, directory)
+        mv(joinpath(directory, "PowerSystemsTestData-master"), joinpath(directory, "data"), force=true)
+        return joinpath(directory, "data")
+    end
+
+    function unzip(::Type{<:BSD}, filename, directory)
+        @assert success(`tar -xvf $filename -C $directory`) "Unable to extract $filename to $directory"
+    end
+
+    function unzip(::Type{Windows}, filename, directory)
+        home = (Base.VERSION < v"0.7-") ? JULIA_HOME : Sys.BINDIR
+        @assert success(`$home/7z x $filename -y -o$directory`) "Unable to extract $filename to $directory"
+    end
+
+end
+

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,0 +1,8 @@
+
+
+@testset "TestData" begin
+
+    @test download(PowerSystems.TestData) |> abspath == joinpath(@__DIR__, "../data") |> abspath
+
+end # testset
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using Dates
 gl = global_logger()
 global_logger(ConsoleLogger(gl.stream, Logging.Error))
 
+include("data.jl")
+
 @testset "Check PowerSystems Data" begin
     @info "Check bus index"
     include("busnumberchecks.jl")


### PR DESCRIPTION
**Usage**:

```julia
$ julia --project
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.1.0 (2019-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |


julia> using PowerSystems

julia> download(PowerSystems.TestData)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   133    0   133    0     0    372      0 --:--:-- --:--:-- --:--:--   372
100 11.8M    0 11.8M    0     0  2764k      0 --:--:--  0:00:04 --:--:-- 3307k
"/Users/$USER/GitRepos/PowerSystems.jl/data"

shell> ls data
RTS_GMLC                data_14bus.jl           data_5bus.jl            data_5bus_dc_psst.jl    data_5bus_uc.jl         forecasts               pm_data
csv_118                 data_14bus_pu.jl        data_5bus_dc.jl         data_5bus_pu.jl         data_5bus_uc_psst.jl    matpower                psse_raw

```

**Documentation**:

```julia
help?> download
search: download

  Download Power System Data into a "data" folder in given argument path. Defaults to the root of
  the PowerSystems package.

  Returns the downloaded folder name.
```

**Build**:

This function is also included in the build script:

```julia
$ julia --project
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.1.0 (2019-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> 

shell> ls data
ls: data: No such file or directory

(PowerSystems) pkg> build
  Building CodecZlib ───→ `~/.julia/packages/CodecZlib/DAjXH/deps/build.log`
  Building PowerSystems → `~/GitRepos/PowerSystems.jl/deps/build.log`
 Resolving package versions...

shell> ls data
RTS_GMLC                data_14bus.jl           data_5bus.jl            data_5bus_dc_psst.jl    data_5bus_uc.jl         forecasts               pm_data
csv_118                 data_14bus_pu.jl        data_5bus_dc.jl         data_5bus_pu.jl         data_5bus_uc_psst.jl    matpower                psse_raw

julia> pwd()
"/Users/$USER/GitRepos/PowerSystems.jl"
```

Resolves #150 