### PR TITLE
Refactor parser unit tests and fix test failures.

### DIFF
--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -99,6 +99,8 @@ abstract type PowerSystemDevice <: PowerSystemComponent end
 # supertype for generation technologies (thermal, renewable, etc.)
 abstract type TechnicalParams <: PowerSystemComponent end
 
+include("common.jl")
+
 # Include utilities
 include("utils/IO/base_checks.jl")
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,8 +1,8 @@
 
 "From http://www.pserc.cornell.edu/matpower/MATPOWER-manual.pdf Table B-4"
 @enum GeneratorCostModel begin
-    piecewise_linear = 1
-    polynomial = 2
+    PIECEWISE_LINEAR = 1
+    POLYNOMIAL = 2
 end
 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -4,3 +4,9 @@
     piecewise_linear = 1
     polynomial = 2
 end
+
+
+"Thrown upon detection of user data that is not supported."
+struct DataFormatError <: Exception
+    msg::String
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,6 @@
+
+"From http://www.pserc.cornell.edu/matpower/MATPOWER-manual.pdf Table B-4"
+@enum GeneratorCostModel begin
+    piecewise_linear = 1
+    polynomial = 2
+end

--- a/src/models/branches/lines.jl
+++ b/src/models/branches/lines.jl
@@ -14,21 +14,28 @@ struct Line <: Branch
     anglelimits::Min_Max #Degrees
 end
 
-function Line(name::String, available::Bool, connectionpoints::From_To_Bus,
-    r::Float64, x::Float64, b::From_To_Float, rate::Float64, anglelimits::Float64)
-anglelimits = (min = -anglelimits, max = anglelimits)
-return Line(name, available, connectionpoints, r, x, b, rate, anglelimits)
+function Line(name::String,
+              available::Bool,
+              connectionpoints::From_To_Bus,
+              r::Float64,
+              x::Float64,
+              b::From_To_Float,
+              rate::Float64,
+              anglelimits::Float64)
+    return Line(name, available, connectionpoints, r, x, b, rate,
+                (min=-anglelimits, max=anglelimits))
 end
 
-Line(; name = "init",
-       available = false,
-       connectionpoints = (from = Bus(), to = Bus()),
-       r = 0.0,
-       x = 0.0,
-       b = (from=0.0, to =0.0),
-       rate = 0.0,
-       anglelimits = (min = -1.57, max = 1.57)
-    ) = Line(name, available, connectionpoints, r, x, b, rate, anglelimits)
+function Line(; name="init",
+              available=false,
+              connectionpoints=From_To_Bus((from=Bus(), to=Bus())),
+              r=0.0,
+              x=0.0,
+              b=(from=0.0, to=0.0),
+              rate=0.0,
+              anglelimits=(min=-1.57, max=1.57))
+    return Line(name, available, connectionpoints, r, x, b, rate, anglelimits)
+end
 
 struct MonitoredLine <: Branch
     name::String
@@ -42,18 +49,13 @@ struct MonitoredLine <: Branch
     anglelimits::Min_Max #Degrees
 end
 
-function MonitoredLine(name::String, available::Bool, connectionpoints::From_To_Bus,
-              r::Float64, x::Float64, b::From_To_Float, flowlimits::FromTo_ToFrom_Float, rate::Float64, anglelimits::Float64)
-        anglelimit_tuple = (min = -anglelimits, max = anglelimits)
-        return MonitoredLine(name, available, connectionpoints, r, x, b, flowlimits, rate, anglelimit_tuple)
+function MonitoredLine(; name="init",
+                       available=false,
+                       connectionpoints=From_To_Bus((from=Bus(), to=Bus())),
+                       r=0.0,
+                       x=0.0,
+                       b=(from=0.0, to=0.0),
+                       rate=0.0,
+                       anglelimits=(min=-90.0, max=90.0))
+    return Line(name, available, connectionpoints, r, x, b, rate, anglelimits)
 end
-
-MonitoredLine(; name = "init",
-       available = false,
-       connectionpoints = (from = Bus(), to = Bus()),
-       r = 0.0,
-       x = 0.0,
-       b = (from=0.0, to =0.0),
-       rate = (from_to=0.0, to_from=0.0),
-       anglelimits = (min = -90, max = 90)
-    ) = Line(name, available, connectionpoints, r, x, b, rate, anglelimits)

--- a/src/parsers/dict_to_struct.jl
+++ b/src/parsers/dict_to_struct.jl
@@ -425,7 +425,7 @@ function branch_dict_parser(dict::Dict{String,Any},Branches::Array{B,1}) where {
                                     line_dict["r"],
                                     line_dict["x"],
                                     line_dict["b"],
-                                    line_dict["rate"],
+                                    float(line_dict["rate"]),
                                     line_dict["anglelimits"]
                                     ))
             end

--- a/src/parsers/im_io/common.jl
+++ b/src/parsers/im_io/common.jl
@@ -17,7 +17,7 @@ function arrays_to_dicts!(data::Dict{String,Any})
                 if !(haskey(dict, key))
                     dict[key] = item
                 else
-                    warn(LOGGER, "skipping component $(item["index"]) from the $(k) table because a component with the same id already exists")
+                    @warn "skipping component $(item["index"]) from the $(k) table because a component with the same id already exists"
                 end
             end
             data[k] = dict

--- a/src/parsers/im_io/data.jl
+++ b/src/parsers/im_io/data.jl
@@ -7,7 +7,7 @@ function update_data!(data::Dict{String,Any}, new_data::Dict{String,Any})
             error("update_data requires datasets in the same units, try make_per_unit and make_mixed_units")
         end
     else
-        warn(LOGGER, "running update_data with data that does not include per_unit field, units may be incorrect")
+        @warn "running update_data with data that does not include per_unit field, units may be incorrect"
     end
     _update_data!(data, new_data)
 end
@@ -40,11 +40,11 @@ function im_replicate(sn_data::Dict{String,Any}, count::Int; global_keys::Set{St
     end
 
     if length(global_keys) <= 0
-        warn(LOGGER, "deprecation warning, calls to replicate should explicitly specify a set of global_keys")
+        @warn "deprecation warning, calls to replicate should explicitly specify a set of global_keys"
         # old default
         for (k,v) in sn_data
              if !(typeof(v) <: Dict)
-                warn(LOGGER, "adding global key $(k)")
+                @warn "adding global key $(k)"
                 push!(global_keys, k)
              end
         end
@@ -92,7 +92,7 @@ component_table(data::Dict{String,Any}, component::String, field::String) = comp
 function _component_table(data::Dict{String,Any}, component::String, fields::Vector{String})
     comps = data[component]
     if !_iscomponentdict(comps)
-        error(LOGGER, "$(component) does not appear to refer to a component list")
+        @error "$(component) does not appear to refer to a component list"
     end
 
     items = []

--- a/src/parsers/im_io/matlab.jl
+++ b/src/parsers/im_io/matlab.jl
@@ -38,7 +38,7 @@ function parse_matlab_string(data_string::String; extended=false)
             function_name = value
         elseif occursin("=",line)
             if struct_name != nothing && !occursin("$(struct_name).", line)
-                warn(LOGGER, "assignments are expected to be made to \"$(struct_name)\" but given: $(line)")
+                @warn "assignments are expected to be made to \"$(struct_name)\" but given: $(line)"
             end
 
             if occursin("[", line)
@@ -61,7 +61,7 @@ function parse_matlab_string(data_string::String; extended=false)
                 matlab_dict[name] = value
             end
         else
-            warn(LOGGER, "Matlab parser skipping the following line:\n  $(line)")
+            @error "Matlab parser skipping the following line:\n  $(line)"
         end
 
         index += 1
@@ -183,7 +183,7 @@ function parse_matlab_data(lines, index, start_char, end_char)
         if columns < 0
             columns = length(row_items)
         elseif columns != length(row_items)
-            error(LOGGER, "matrix parsing error, inconsistent number of items in each row\n$(row)")
+            @error "matrix parsing error, inconsistent number of items in each row\n$(row)"
         end
     end
 
@@ -201,10 +201,10 @@ function parse_matlab_data(lines, index, start_char, end_char)
         column_names_string = replace(column_names_string, "%column_names%" => "")
         column_names = split(column_names_string)
         if length(matrix[1]) != length(column_names)
-            error(LOGGER, "column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)")
+            @error "column name parsing error, data rows $(length(matrix[1])), column names $(length(column_names)) \n$(column_names)"
         end
         if any([column_name == "index" for column_name in column_names])
-            error(LOGGER, "column name parsing error, \"index\" is a reserved column name \n$(column_names)")
+            @error "column name parsing error, \"index\" is a reserved column name \n$(column_names)"
         end
         matrix_dict["column_names"] = column_names
     end
@@ -288,7 +288,7 @@ function check_type(typ, value)
             value = parse(typ, value)
             return value
         catch e
-            error(LOGGER, "parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data")
+            @error "parsing error, the matlab string \"$(value)\" can not be parsed to $(typ) data"
             rethrow(e)
         end
     else
@@ -296,7 +296,7 @@ function check_type(typ, value)
             value = typ(value)
             return value
         catch e
-            error(LOGGER, "parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data")
+            @error "parsing error, the matlab value $(value) of type $(typeof(value)) can not be parsed to $(typ) data"
             rethrow(e)
         end
     end

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -2,13 +2,13 @@
 MAPPING_BUSNUMBER2INDEX = Dict{Int64, Int64}()
 
 """ 
-Takes a dictionary parsered by PowerModels and returns a PowerSystems
-dictionary.  Currently Supports MATPOWER and PSSE data files paresed by
+Takes a dictionary parsed by PowerModels and returns a PowerSystems
+dictionary.  Currently Supports MATPOWER and PSSE data files parsed by
 PowerModels
 """
 function pm2ps_dict(data::Dict{String,Any})
     if length(data["bus"]) < 1
-        @error "There are no buses in this file" # TODO: raise error here?
+        throw(DataFormatError("There are no buses in this file."))
     end
     ps_dict = Dict{String,Any}()
     ps_dict["name"] = data["name"]
@@ -216,25 +216,34 @@ function make_ren_gen(gen_name, d, bus)
 end
 
 function make_thermal_gen(gen_name, d, bus)
-    if d["model"] ==1
+    model = GeneratorCostModel(d["model"])
+    if model == piecewise_linear::GeneratorCostModel
         cost_component = d["cost"]
         power_p = [i for (ix,i) in enumerate(cost_component) if isodd(ix)]
         cost_p =  [i for (ix,i) in enumerate(cost_component) if iseven(ix)]./power_p
         cost = [(p,c) for (p,c) in zip(cost_p,power_p)]
         fixedcost = cost[1][2]
-    elseif d["model"] ==2
-        if d["ncost"] == 2
+    elseif model == polynomial::GeneratorCostModel
+        if d["ncost"] == 0
+            cost = x-> 0
+        elseif d["ncost"] == 1
+            cost = x-> d["cost"][1]
+        elseif d["ncost"] == 2
             cost = x-> d["cost"][1]*x + d["cost"][2]
         elseif d["ncost"] == 3
             cost = x-> d["cost"][1]*x^2 + d["cost"][2]*x + d["cost"][3]
         elseif d["ncost"] == 4
             cost = x-> d["cost"][1]*x^3 + d["cost"][2]*x^2 + d["cost"][3]*x + d["cost"][4]
+        else
+            throw(DataFormatError("invalid value for ncost: $(d["ncost"])"))
         end
-        fixedcost = cost(0)
-    else
-        cost = d["cost"]
-        fixedcost = 0.0
+
+        # TODO: Reviewers:  Is this correct?
+        fixedcost = cost(d["pmin"])
     end
+
+    # GitHub #148: ramp_agc isn't always present. This value may not be correct.
+    ramp_agc = get(d, "ramp_agc", 0.0)
     thermal_gen = Dict{String,Any}("name" => gen_name,
                                     "available" => d["gen_status"],
                                     "bus" => make_bus(bus),
@@ -242,7 +251,7 @@ function make_thermal_gen(gen_name, d, bus)
                                                                 "activepowerlimits" => (min=d["pmin"], max=d["pmax"]),
                                                                 "reactivepower" => d["qg"],
                                                                 "reactivepowerlimits" => (min=d["qmin"], max=d["qmax"]),
-                                                                "ramplimits" => (up=d["ramp_agc"],down=d["ramp_agc"]),
+                                                                "ramplimits" => (up=ramp_agc, down=ramp_agc),
                                                                 "timelimits" => nothing),
                                     "econ" => Dict{String,Any}("capacity" => d["pmax"],
                                                                 "variablecost" => cost,
@@ -285,7 +294,7 @@ function read_gen(data,Buses)
                     Generators["Renewable"]["WIND"][gen_name] = make_ren_gen(gen_name, d, bus)
                 end
             else
-                bus =find_bus(Buses,d)
+                bus =find_bus(Buses, d)
                 Generators["Thermal"][gen_name] = make_thermal_gen(gen_name, d, bus)
             end
         end

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -294,7 +294,7 @@ function read_gen(data,Buses)
                     Generators["Renewable"]["WIND"][gen_name] = make_ren_gen(gen_name, d, bus)
                 end
             else
-                bus =find_bus(Buses, d)
+                bus = find_bus(Buses, d)
                 Generators["Thermal"][gen_name] = make_thermal_gen(gen_name, d, bus)
             end
         end

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -1,7 +1,7 @@
 
 MAPPING_BUSNUMBER2INDEX = Dict{Int64, Int64}()
 
-""" 
+"""
 Takes a dictionary parsed by PowerModels and returns a PowerSystems
 dictionary.  Currently Supports MATPOWER and PSSE data files parsed by
 PowerModels
@@ -217,13 +217,13 @@ end
 
 function make_thermal_gen(gen_name, d, bus)
     model = GeneratorCostModel(d["model"])
-    if model == piecewise_linear::GeneratorCostModel
+    if model == PIECEWISE_LINEAR::GeneratorCostModel
         cost_component = d["cost"]
         power_p = [i for (ix,i) in enumerate(cost_component) if isodd(ix)]
         cost_p =  [i for (ix,i) in enumerate(cost_component) if iseven(ix)]./power_p
         cost = [(p,c) for (p,c) in zip(cost_p,power_p)]
         fixedcost = cost[1][2]
-    elseif model == polynomial::GeneratorCostModel
+    elseif model == POLYNOMIAL::GeneratorCostModel
         if d["ncost"] == 0
             cost = x-> 0
         elseif d["ncost"] == 1
@@ -242,7 +242,7 @@ function make_thermal_gen(gen_name, d, bus)
         fixedcost = cost(d["pmin"])
     end
 
-    # GitHub #148: ramp_agc isn't always present. This value may not be correct.
+    # TODO GitHub #148: ramp_agc isn't always present. This value may not be correct.
     ramp_agc = get(d, "ramp_agc", 0.0)
     thermal_gen = Dict{String,Any}("name" => gen_name,
                                     "available" => d["gen_status"],

--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -15,7 +15,7 @@ end
 
 ""
 function calc_branch_y(branch::Dict{String,Any})
-    y = pinv(branch["br_r"] + im * branch["br_x"])
+    y = LinearAlgebra.pinv(branch["br_r"] + im * branch["br_x"])
     g, b = real(y), imag(y)
     return g, b
 end
@@ -624,7 +624,7 @@ function check_thermal_limits(data::Dict{String,Any})
                 r = branch["br_r"]
                 x = branch["br_x"]
                 z = r + im * x
-                y = pinv(z)
+                y = LinearAlgebra.pinv(z)
                 y_mag = abs.(y[c,c])
 
                 fr_vmax = data["bus"][string(branch["f_bus"])]["vmax"][c]
@@ -690,7 +690,7 @@ function check_current_limits(data::Dict{String,Any})
                 r = branch["br_r"]
                 x = branch["br_x"]
                 z = r + im * x
-                y = pinv(z)
+                y = LinearAlgebra.pinv(z)
                 y_mag = abs.(y[c,c])
 
                 fr_vmax = data["bus"][string(branch["f_bus"])]["vmax"][c]

--- a/src/parsers/pm_io/multiconductor.jl
+++ b/src/parsers/pm_io/multiconductor.jl
@@ -165,7 +165,7 @@ Base.:^(a::MultiConductorMatrix, b::AbstractFloat) = MultiConductorMatrix(a.valu
 
 
 LinearAlgebra.inv(a::MultiConductorMatrix) = MultiConductorMatrix(inv(a.values))
-LinearAlgebra.pinv(a::MultiConductorMatrix) = MultiConductorMatrix(pinv(a.values))
+LinearAlgebra.pinv(a::MultiConductorMatrix) = MultiConductorMatrix(LinearAlgebra.pinv(a.values))
 
 Base.real(a::MultiConductorVector) = MultiConductorVector(real(a.values))
 Base.real(a::MultiConductorMatrix) = MultiConductorMatrix(real(a.values))

--- a/src/parsers/pm_io/pti.jl
+++ b/src/parsers/pm_io/pti.jl
@@ -253,7 +253,7 @@ function parse_line_element!(data::Dict, elements::Array, section::AbstractStrin
             element = popfirst!(elements)
         catch message
             if isa(message, ArgumentError)
-                debug(LOGGER, "Have run out of elements in $section at $field")
+                @debug "Have run out of elements in $section at $field"
                 push!(missing, field)
                 continue
             end
@@ -323,8 +323,8 @@ function get_line_elements(line::AbstractString)::Array
     matches = collect((m.match for m = eachmatch(match_string, line, overlap=false)))
     #matches = matchall(match_string, line)
 
-    debug(LOGGER, "$line")
-    debug(LOGGER, "$matches")
+    @debug "$line"
+    @debug "$matches"
 
     elements = []
     comment = ""
@@ -361,7 +361,7 @@ function parse_pti_data(data_io::IO, sections::Array)
     section_data = Dict{String,Any}()
 
     for (line_number, line) in enumerate(data_lines)
-        debug(LOGGER, "$line_number: $line")
+        @debug "$line_number: $line"
 
         (elements, comment) = get_line_elements(line)
 
@@ -374,7 +374,7 @@ function parse_pti_data(data_io::IO, sections::Array)
             end
 
             match_string = r"\s*END OF ([\w\s-]+) DATA(?:, BEGIN ([\w\s-]+) DATA)?"
-            debug(LOGGER, "$comment")
+            @debug "$comment"
             matches = match(match_string, comment)
 
             if !isa(matches, Nothing)
@@ -409,7 +409,7 @@ function parse_pti_data(data_io::IO, sections::Array)
                 continue
             end
 
-            debug(LOGGER, join(["Section:", section], " "))
+            @debug join(["Section:", section], " ")
             if !(section in ["CASE IDENTIFICATION","TRANSFORMER","VOLTAGE SOURCE CONVERTER","MULTI-TERMINAL DC","TWO-TERMINAL DC","GNE DEVICE"])
                 section_data = Dict{String,Any}()
                 try
@@ -586,7 +586,7 @@ function parse_pti_data(data_io::IO, sections::Array)
             end
         end
         if subsection != ""
-            debug(LOGGER, "appending data")
+            @debug "appending data"
         end
         add_section_data!(pti_data, section_data, section)
     end

--- a/src/utils/IO/base_checks.jl
+++ b/src/utils/IO/base_checks.jl
@@ -1,10 +1,15 @@
-function orderedlimits(limits::Union{NamedTuple{(:min, :max),Tuple{Float64,Float64}},Nothing},limsname::String)
-    if isa(limits,Nothing)
-        @info "'$limsname' limits defined as nothing"
+function orderedlimits(limits::Union{NamedTuple{(:min, :max), Tuple{Float64, Float64}},
+                                     Nothing},
+                       limitsname::String)
+    if isa(limits, Nothing)
+        @info "'$limitsname' limits defined as nothing"
     else
-        if limits.max < limits.min @error "'$limsname' limits not in ascending order" else limits end
+        if limits.max < limits.min
+            throw(DataFormatError("$limitsname limits not in ascending order"))
+        end
     end
-    return limits
+
+    limits
 end
 
 
@@ -25,15 +30,14 @@ function getresolution(ts::TimeSeries.TimeArray)
         elseif mod(timediff,Dates.Millisecond(Dates.Second(1))) == Dates.Millisecond(0)
             push!(res,Dates.Second(timediff/Dates.Millisecond(Dates.Second(1))))
         else
-            @error "I can't understand the resolution of the timeseries"
+            throw(DataFormatError("cannot understand the resolution of the timeseries"))
         end
     end
 
     if length(res) > 1
-        @warn "Timeseries has non-uniform resolution: this is currently not supported"
-    else
-        resolution = res[1]
+        throw(DataFormatError("timeseries has non-uniform resolution: this is currently " \
+                              "not supported"))
     end
-    
-    return resolution
+
+    return res[1]
 end

--- a/src/utils/IO/base_checks.jl
+++ b/src/utils/IO/base_checks.jl
@@ -9,7 +9,7 @@ function orderedlimits(limits::Union{NamedTuple{(:min, :max), Tuple{Float64, Flo
         end
     end
 
-    limits
+    return limits
 end
 
 

--- a/src/utils/data.jl
+++ b/src/utils/data.jl
@@ -32,7 +32,7 @@ module UtilsData
 
     """
     Download Power System Data into a "data" folder in given argument path.
-    Skip the actual download if the folder already exists or if force=false.
+    Skip the actual download if the folder already exists and force=false.
     Defaults to the root of the PowerSystems package.
 
     Returns the downloaded folder name.

--- a/src/utils/data.jl
+++ b/src/utils/data.jl
@@ -32,17 +32,24 @@ module UtilsData
 
     """
     Download Power System Data into a "data" folder in given argument path.
+    Skip the actual download if the folder already exists or if force=false.
     Defaults to the root of the PowerSystems package.
 
     Returns the downloaded folder name.
     """
-    function Base.download(::Type{TestData}, folder::AbstractString=joinpath(@__DIR__, "../..") |> abspath)
-        tempfilename = Base.download(POWERSYSTEMSTESTDATA_URL)
+    function Base.download(::Type{TestData};
+                           folder::AbstractString=joinpath(@__DIR__, "../..") |> abspath,
+                           force::Bool=false)
         directory = folder |> normpath |> abspath
-        mkpath(directory)
-        unzip(os, tempfilename, directory)
-        mv(joinpath(directory, "PowerSystemsTestData-master"), joinpath(directory, "data"), force=true)
-        return joinpath(directory, "data")
+        data = joinpath(directory, "data")
+        if !isdir(data) || force
+            tempfilename = Base.download(POWERSYSTEMSTESTDATA_URL)
+            mkpath(directory)
+            unzip(os, tempfilename, directory)
+            mv(joinpath(directory, "PowerSystemsTestData-master"), data, force=true)
+        end
+
+        return data
     end
 
     function unzip(::Type{<:BSD}, filename, directory)

--- a/test/branchchecks_testing.jl
+++ b/test/branchchecks_testing.jl
@@ -1,29 +1,5 @@
 import TimeSeries: TimeArray
 
-nodes5 = [
-    Bus(1, "nodeA", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-    Bus(2, "nodeB", "PQ", 0, 1.0, (min = 0.9, max=1.05), 230),
-    Bus(3, "nodeC", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-    Bus(4, "nodeD", "SF", 0, 1.0, (min = 0.9, max=1.05), 230),
-    Bus(5, "nodeE", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-]
-
-branches_test = [
-    Line("1", true, (from=nodes5[1], to=nodes5[2]), 0.00281, 0.0281,
-         (from=0.00356, to=0.00356), 400.0, (min=-360.0, max=360.0)),
-    Line("2", true, (from=nodes5[1], to=nodes5[4]), 0.00304, 0.0304,
-         (from=0.00329, to=0.00329), 3960.0, (min=-360.0, max=75.0)),
-    Line("3", true, (from=nodes5[1], to=nodes5[5]), 0.00064, 0.0064,
-         (from=0.01563, to=0.01563), 18812.0, (min=-75.0, max=360.0)),
-    Line("4", true, (from=nodes5[2], to=nodes5[3]), 0.00108, 0.0108,
-         (from=0.00926, to=0.00926), 11148.0, (min=0.0, max=0.0)),
-    Line("5", true, (from=nodes5[3], to=nodes5[4]), 0.00297, 0.0297,
-         (from=0.00337, to=0.00337), 4053.0, (min=-1.2, max=60.0)),
-    Line("6", true, (from=nodes5[4], to=nodes5[5]), 0.00297, 0.0297,
-         (from=0.00337, to=00.00337), 240.0, (min=-1.17, max=1.17))
-]
-
-
 @testset "Time resolution" begin
     twomins = TimeArray([DateTime(today()) + Dates.Minute(i * 2) for i in 1:5], ones(5))
     oneday = TimeArray([DateTime(today()) + Dates.Day(i) for i in 1:5], ones(5))
@@ -37,6 +13,29 @@ branches_test = [
 end
 
 @testset "Angle limits" begin
+    nodes5 = [
+        Bus(1, "nodeA", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+        Bus(2, "nodeB", "PQ", 0, 1.0, (min = 0.9, max=1.05), 230),
+        Bus(3, "nodeC", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+        Bus(4, "nodeD", "SF", 0, 1.0, (min = 0.9, max=1.05), 230),
+        Bus(5, "nodeE", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+    ]
+
+    branches_test = [
+        Line("1", true, (from=nodes5[1], to=nodes5[2]), 0.00281, 0.0281,
+             (from=0.00356, to=0.00356), 400.0, (min=-360.0, max=360.0)),
+        Line("2", true, (from=nodes5[1], to=nodes5[4]), 0.00304, 0.0304,
+             (from=0.00329, to=0.00329), 3960.0, (min=-360.0, max=75.0)),
+        Line("3", true, (from=nodes5[1], to=nodes5[5]), 0.00064, 0.0064,
+             (from=0.01563, to=0.01563), 18812.0, (min=-75.0, max=360.0)),
+        Line("4", true, (from=nodes5[2], to=nodes5[3]), 0.00108, 0.0108,
+             (from=0.00926, to=0.00926), 11148.0, (min=0.0, max=0.0)),
+        Line("5", true, (from=nodes5[3], to=nodes5[4]), 0.00297, 0.0297,
+             (from=0.00337, to=0.00337), 4053.0, (min=-1.2, max=60.0)),
+        Line("6", true, (from=nodes5[4], to=nodes5[5]), 0.00297, 0.0297,
+             (from=0.00337, to=00.00337), 240.0, (min=-1.17, max=1.17))
+    ]
+
     PowerSystems.checkanglelimits!(branches_test)
     @test branches_test[1].anglelimits == (min=-1.57, max=1.57)
     @test branches_test[2].anglelimits == (min=-1.57, max=75.0 * (π / 180))
@@ -44,4 +43,12 @@ end
     @test branches_test[4].anglelimits == (min=-1.57, max=1.57)
     @test branches_test[5].anglelimits == (min=-1.2, max=60.0 * (π / 180))
     @test branches_test[6].anglelimits == (min=-1.17, max=1.17)
+
+    bad_angle_limits = [
+        Line("1", true, (from=nodes5[1], to=nodes5[2]), 0.00281, 0.0281,
+             (from=0.00356, to=0.00356), 400.0, (min=360.0, max=-360.0))
+    ]
+
+    @test_throws(PowerSystems.DataFormatError,
+                 PowerSystems.checkanglelimits!(bad_angle_limits))
 end

--- a/test/branchchecks_testing.jl
+++ b/test/branchchecks_testing.jl
@@ -1,31 +1,47 @@
-using PowerSystems
+import TimeSeries: TimeArray
 
-nodes5    = [Bus(1,"nodeA", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-             Bus(2,"nodeB", "PQ", 0, 1.0, (min = 0.9, max=1.05), 230),
-             Bus(3,"nodeC", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-             Bus(4,"nodeD", "SF", 0, 1.0, (min = 0.9, max=1.05), 230),
-             Bus(5,"nodeE", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
-        ];
+nodes5 = [
+    Bus(1, "nodeA", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+    Bus(2, "nodeB", "PQ", 0, 1.0, (min = 0.9, max=1.05), 230),
+    Bus(3, "nodeC", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+    Bus(4, "nodeD", "SF", 0, 1.0, (min = 0.9, max=1.05), 230),
+    Bus(5, "nodeE", "PV", 0, 1.0, (min = 0.9, max=1.05), 230),
+]
 
-branches_test = [Line("1", true,  (from=nodes5[1],to=nodes5[2]), 0.00281, 0.0281,  (from=0.00356, to=0.00356), 400.0,  (min = -360.0,max = 360.0)),
-             Line("2", true,  (from=nodes5[1],to=nodes5[4]), 0.00304, 0.0304,  (from=0.00329, to=0.00329), 3960.0,  (min = -360.0,max = 75.0)),
-             Line("3", true,  (from=nodes5[1],to=nodes5[5]), 0.00064, 0.0064,  (from=0.01563, to=0.01563), 18812.0,  (min = -75.0,max = 360.0)),
-             Line("4", true,  (from=nodes5[2],to=nodes5[3]), 0.00108, 0.0108,  (from=0.00926, to=0.00926), 11148.0,  (min = 0.0,max = 0.0)),
-             Line("5", true,  (from=nodes5[3],to=nodes5[4]), 0.00297, 0.0297,  (from=0.00337, to=0.00337), 4053.0,  (min = -1.2,max = 60.0)),
-             Line("6", true,  (from=nodes5[4],to=nodes5[5]), 0.00297, 0.0297,  (from=0.00337, to=00.00337), 240.0,  (min = -1.17,max = 1.17))
-             ];
+branches_test = [
+    Line("1", true, (from=nodes5[1], to=nodes5[2]), 0.00281, 0.0281,
+         (from=0.00356, to=0.00356), 400.0, (min=-360.0, max=360.0)),
+    Line("2", true, (from=nodes5[1], to=nodes5[4]), 0.00304, 0.0304,
+         (from=0.00329, to=0.00329), 3960.0, (min=-360.0, max=75.0)),
+    Line("3", true, (from=nodes5[1], to=nodes5[5]), 0.00064, 0.0064,
+         (from=0.01563, to=0.01563), 18812.0, (min=-75.0, max=360.0)),
+    Line("4", true, (from=nodes5[2], to=nodes5[3]), 0.00108, 0.0108,
+         (from=0.00926, to=0.00926), 11148.0, (min=0.0, max=0.0)),
+    Line("5", true, (from=nodes5[3], to=nodes5[4]), 0.00297, 0.0297,
+         (from=0.00337, to=0.00337), 4053.0, (min=-1.2, max=60.0)),
+    Line("6", true, (from=nodes5[4], to=nodes5[5]), 0.00297, 0.0297,
+         (from=0.00337, to=00.00337), 240.0, (min=-1.17, max=1.17))
+]
 
 
-@test try @assert PowerSystems.getresolution(TimeSeries.TimeArray([DateTime(Dates.today())+Dates.Minute(i*2) for i in 1:5],ones(5)))==Dates.Minute(2); true finally end
-@test try @assert PowerSystems.getresolution(TimeSeries.TimeArray([DateTime(Dates.today())+Dates.Day(i) for i in 1:5],ones(5)))==Dates.Day(1); true finally end
-@test try @assert PowerSystems.getresolution(TimeSeries.TimeArray([DateTime(Dates.today())+Dates.Second(i) for i in 1:5],ones(5)))==Dates.Second(1); true finally end
-@test try @assert PowerSystems.getresolution(TimeSeries.TimeArray([DateTime(Dates.today())+Dates.Hour(i) for i in 1:5],ones(5)))==Dates.Hour(1); true finally end
+@testset "Time resolution" begin
+    twomins = TimeArray([DateTime(today()) + Dates.Minute(i * 2) for i in 1:5], ones(5))
+    oneday = TimeArray([DateTime(today()) + Dates.Day(i) for i in 1:5], ones(5))
+    onesec = TimeArray([DateTime(today()) + Dates.Second(i) for i in 1:5], ones(5))
+    onehour = TimeArray([DateTime(today()) + Dates.Hour(i) for i in 1:5], ones(5))
 
-@test try PowerSystems.checkanglelimits!(branches_test); true finally end
+    @test PowerSystems.getresolution(twomins) == Dates.Minute(2)
+    @test PowerSystems.getresolution(oneday) == Dates.Day(1)
+    @test PowerSystems.getresolution(onesec) == Dates.Second(1)
+    @test PowerSystems.getresolution(onehour) == Dates.Hour(1)
+end
 
-@test try @assert (branches_test[1].anglelimits) == (min = -1.57,max = 1.57); true finally end
-@test try @assert (branches_test[2].anglelimits) == (min = -1.57,max = 75.0*(π/180)); true finally end
-@test try @assert (branches_test[3].anglelimits) == (min = -75.0*(π/180),max = 1.57); true finally end
-@test try @assert (branches_test[4].anglelimits) == (min = -1.57,max = 1.57); true finally end
-@test try @assert (branches_test[5].anglelimits) == (min = -1.2,max = 60.0*(π/180)); true finally end
-@test try @assert (branches_test[6].anglelimits) == (min = -1.17,max = 1.17); true finally end
+@testset "Angle limits" begin
+    PowerSystems.checkanglelimits!(branches_test)
+    @test branches_test[1].anglelimits == (min=-1.57, max=1.57)
+    @test branches_test[2].anglelimits == (min=-1.57, max=75.0 * (π / 180))
+    @test branches_test[3].anglelimits == (min=-75.0 * (π / 180), max=1.57)
+    @test branches_test[4].anglelimits == (min=-1.57, max=1.57)
+    @test branches_test[5].anglelimits == (min=-1.2, max=60.0 * (π / 180))
+    @test branches_test[6].anglelimits == (min=-1.17, max=1.17)
+end

--- a/test/busnumberchecks.jl
+++ b/test/busnumberchecks.jl
@@ -1,17 +1,22 @@
+
+#note: may have to remove the 'data' folder from this directory and run 'build PowerSystems'
+base_dir = dirname(dirname(pathof(PowerSystems)))
+
+ps_dict = PowerSystems.parsestandardfiles(joinpath(MATPOWER_DIR, "case5_re.m"))
+
+buses, generators, storage, branches, loads, loadZones, shunts, services =
+    PowerSystems.ps_dict2ps_struct(ps_dict);
+sys = PowerSystems.PowerSystem(buses, generators, loads, branches, storage,
+                               ps_dict["baseMVA"]);
+
 @testset "Check bus index" begin
+    @test sort([b.number for b in sys.buses]) == [1, 2, 3, 4, 5]
+    @test sort(collect(Set([b.connectionpoints.from.number for b in sys.branches]))) ==
+        [1, 2, 4, 5]
+    @test sort(collect(Set([b.connectionpoints.to.number for b in sys.branches]))) ==
+        [1, 3, 4, 5]
 
-base_dir = dirname(dirname(pathof(PowerSystems))) #note: may have to remove the 'data' folder from this directory and run 'build PowerSystems'
-
-ps_dict = PowerSystems.parsestandardfiles(abspath(joinpath(base_dir, "data/matpower/case5_re.m")));
-
-buses, generators, storage, branches, loads, loadZones, shunts, services = PowerSystems.ps_dict2ps_struct(ps_dict);
-sys = PowerSystems.PowerSystem(buses, generators, loads, branches, storage, ps_dict["baseMVA"]);
-
-@test sort([b.number for b in sys.buses]) == [1, 2, 3, 4, 5]
-@test sort(collect(Set([b.connectionpoints.from.number for b in sys.branches]))) == [1, 2, 4, 5]
-@test sort(collect(Set([b.connectionpoints.to.number for b in sys.branches]))) == [1, 3, 4, 5]
-
-# TOOD: add test for loadzones testing MAPPING_BUSNUMBER2INDEX
+    # TODO: add test for loadzones testing MAPPING_BUSNUMBER2INDEX
 
 end
 

--- a/test/cdmparse.jl
+++ b/test/cdmparse.jl
@@ -1,69 +1,36 @@
-using Logging
-using PowerSystems
-
-
-
-basedir = abspath(joinpath(dirname(dirname(Base.find_package("PowerSystems"))), "data/RTS_GMLC"))
-data_dict = nothing
-cdm_dict = nothing
-sys_rts_da = nothing
-sys_rts_rt = nothing
-
-@test try
-    @info "parsing data from $basedir into ps_dict"
-    global data_dict = PowerSystems.read_csv_data(basedir)
-    true
-finally
+@testset "PowerSystems dict parsing" begin
+    @info "parsing data from $RTS_GMLC_DIR into ps_dict"
+    data_dict = PowerSystems.read_csv_data(RTS_GMLC_DIR)
+    @test haskey(data_dict, "timeseries_pointers")
 end
 
-@test haskey(data_dict,"timeseries_pointers")
+@testset "CDM parsing" begin
+    cdm_dict = nothing
+    @info "parsing data from $RTS_GMLC_DIR into ps_dict"
+    cdm_dict = PowerSystems.csv2ps_dict(RTS_GMLC_DIR)
+    @test cdm_dict isa Dict && haskey(cdm_dict, "loadzone")
 
-@test try
-    @info "parsing data from $basedir into ps_dict"
-    global cdm_dict = PowerSystems.csv2ps_dict(basedir)
-    true
-finally
-end
-
-@test (cdm_dict isa Dict) & haskey(cdm_dict,"loadzone") == true
-
-@test try
     @info "assigning time series data for DA"
-    global cdm_dict = PowerSystems.assign_ts_data(cdm_dict,cdm_dict["forecast"]["DA"])
-    true
-finally
-end
+    cdm_dict = PowerSystems.assign_ts_data(cdm_dict, cdm_dict["forecast"]["DA"])
+    @test length(cdm_dict["gen"]["Renewable"]["PV"]["102_PV_1"]["scalingfactor"]) == 24
 
-@test length(cdm_dict["gen"]["Renewable"]["PV"]["102_PV_1"]["scalingfactor"])==24
-
-@test try
     @info "making DA System"
-    global sys_rts_da = PowerSystem(cdm_dict)
-    true
-finally
-end
+    sys_rts_da = PowerSystem(cdm_dict)
+    @test sys_rts_da isa PowerSystem
 
-@test sys_rts_da isa PowerSystem
-
-@test try
     @info "assigning time series data for RT"
-    global cdm_dict = PowerSystems.assign_ts_data(cdm_dict,cdm_dict["forecast"]["RT"])
-    true
-finally
-end 
+    cdm_dict = PowerSystems.assign_ts_data(cdm_dict, cdm_dict["forecast"]["RT"])
+    @test length(cdm_dict["gen"]["Renewable"]["PV"]["102_PV_1"]["scalingfactor"]) == 288
 
-@test length(cdm_dict["gen"]["Renewable"]["PV"]["102_PV_1"]["scalingfactor"])==288
-
-@test try
     @info "making RT System"
-    global sys_rts_rt = PowerSystem(cdm_dict)
-    true
-finally
+    sys_rts_rt = PowerSystem(cdm_dict)
+    @test sys_rts_rt isa PowerSystem
 end
 
-@test (sys_rts_rt isa PowerSystem) == true
-
-
-basedir = joinpath(basedir,"../../test")
-@info "testing bad directory"
-@test PowerSystems.csv2ps_dict(basedir) == Dict{String,Any}("dcline"=>nothing,"baseMVA"=>100.0,"gen"=>nothing,"branch"=>nothing,"services"=>nothing)
+@testset "CDM parsing invalid directory" begin
+    baddir = joinpath(RTS_GMLC_DIR, "../../test")
+    @info "testing bad directory"
+    data = Dict{String, Any}("dcline" => nothing, "baseMVA"=> 100.0, "gen" => nothing,
+                             "branch" => nothing, "services"=> nothing)
+    @test PowerSystems.csv2ps_dict(baddir) == data
+end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,44 +1,77 @@
-#Bus Constructor
-@test try tBus = Bus(); true finally end
-@test try tLoadZones = LoadZones(); true finally end
+@testset "Bus Constructors" begin
+    tBus = Bus()
+    tLoadZones = LoadZones()
+end
 
-#Generation Constructors
-@test try tEconThermal = EconThermal(); true finally end
-@test try tTechThermal = TechThermal(); true finally end
-@test try tThermalGen = ThermalDispatch(); true finally end
-@test try tThermalGenSeason = ThermalGenSeason(); true finally end
-@test try tTechHydro = TechHydro(); true finally end
-@test try tEconHydro = EconHydro(); true finally end
-@test try tHydroFix = HydroFix(); true finally end
-@test try tHydroCurtailment = HydroCurtailment(); true finally end
-@test try tHydroStorage = HydroStorage(); true finally end
-@test try tTechRenewable=TechRenewable(); true finally end
-@test try tEconRenewable = EconRenewable(); true finally end
-@test try tRenewableFix = RenewableFix(); true finally end
-@test try tRenewableFullDispatch = RenewableFullDispatch(); true finally end
-@test try tRenewableCurtailment = RenewableCurtailment(); true finally end
+@testset "Generation Constructors" begin
+    tEconThermal = EconThermal()
+    @test tEconThermal isa PowerSystems.PowerSystemComponent
+    tTechThermal = TechThermal()
+    @test tTechThermal isa PowerSystems.PowerSystemComponent
+    tThermalGen = ThermalDispatch()
+    @test tThermalGen isa PowerSystems.PowerSystemComponent
+    tThermalGenSeason = ThermalGenSeason()
+    @test tThermalGenSeason isa PowerSystems.PowerSystemComponent
+    tTechHydro = TechHydro()
+    @test tTechHydro isa PowerSystems.PowerSystemComponent
+    tEconHydro = EconHydro()
+    @test tEconHydro isa PowerSystems.PowerSystemComponent
+    tHydroFix = HydroFix()
+    @test tHydroFix isa PowerSystems.PowerSystemComponent
+    tHydroCurtailment = HydroCurtailment()
+    @test tHydroCurtailment isa PowerSystems.PowerSystemComponent
+    tHydroStorage = HydroStorage()
+    @test tHydroStorage isa PowerSystems.PowerSystemComponent
+    tTechRenewable = TechRenewable()
+    @test tTechRenewable isa PowerSystems.PowerSystemComponent
+    tEconRenewable = EconRenewable()
+    @test tEconRenewable isa PowerSystems.PowerSystemComponent
+    tRenewableFix = RenewableFix()
+    @test tRenewableFix isa PowerSystems.PowerSystemComponent
+    tRenewableFullDispatch = RenewableFullDispatch()
+    @test tRenewableFullDispatch isa PowerSystems.PowerSystemComponent
+    tRenewableCurtailment = RenewableCurtailment()
+    @test tRenewableCurtailment isa PowerSystems.PowerSystemComponent
+end
 
-#Storage Constructots
-@test try tStorage = GenericBattery(); true finally end
+@testset "Storage Constructors" begin
+    tStorage = GenericBattery()
+    @test tStorage isa PowerSystems.PowerSystemComponent
+end
 
-#Load Constructos
-@test try tPowerLoad = PowerLoad(); true finally end 
-@test try tPowerLoadPF = PowerLoadPF(); true finally end
-@test try tPowerLoad = PowerLoad("init", true, Bus(), 0.0, 0.0); true finally end 
-@test try tPowerLoadPF = PowerLoadPF("init", true, Bus(), 0.0, 1.0); true finally end
-@test try tLoad = InterruptibleLoad(); true finally end
+@testset "Load Constructors" begin
+    tPowerLoad = PowerLoad()
+    @test tPowerLoad isa PowerSystems.PowerSystemComponent
+    tPowerLoadPF = PowerLoadPF()
+    @test tPowerLoadPF isa PowerSystems.PowerSystemComponent
+    tPowerLoad = PowerLoad("init", true, Bus(), 0.0, 0.0)
+    @test tPowerLoad isa PowerSystems.PowerSystemComponent
+    tPowerLoadPF = PowerLoadPF("init", true, Bus(), 0.0, 1.0)
+    @test tPowerLoadPF isa PowerSystems.PowerSystemComponent
+    tLoad = InterruptibleLoad()
+    @test tLoad isa PowerSystems.PowerSystemComponent
+end
 
-#Branch Constructors
-@test try tLine = Line(); true finally end
-@test_skip try tMonitoredLine = MonitoredLine(); true finally end
-@test try tHVDCLine = HVDCLine(); true finally end
-@test try tVSCDCLine = VSCDCLine(); true finally end
-@test try tTransformer2W = Transformer2W(); true finally end
-@test try tTapTransformer = TapTransformer(); true finally end
-@test try tPhaseShiftingTransformer = PhaseShiftingTransformer(); true finally end
+@testset "Branch Constructors" begin
+    tLine = Line()
+    @test tLine isa PowerSystems.PowerSystemComponent
+    tMonitoredLine = MonitoredLine()
+    @test tMonitoredLine isa PowerSystems.PowerSystemComponent
+    tHVDCLine = HVDCLine()
+    @test tHVDCLine isa PowerSystems.PowerSystemComponent
+    tVSCDCLine = VSCDCLine()
+    @test tVSCDCLine isa PowerSystems.PowerSystemComponent
+    tTransformer2W = Transformer2W()
+    @test tTransformer2W isa PowerSystems.PowerSystemComponent
+    tTapTransformer = TapTransformer()
+    @test tTapTransformer isa PowerSystems.PowerSystemComponent
+    tPhaseShiftingTransformer = PhaseShiftingTransformer()
+    @test tPhaseShiftingTransformer isa PowerSystems.PowerSystemComponent
+end
 
-#Product Constructors
-@test try tProportionalReserve = ProportionalReserve(); true finally end
-@test try tStaticReserve = StaticReserve(); true finally end
-
-
+@testset "Product Constructors" begin
+    tProportionalReserve = ProportionalReserve()
+    @test tProportionalReserve isa PowerSystems.Service
+    tStaticReserve = StaticReserve()
+    @test tStaticReserve isa PowerSystems.Service
+end

--- a/test/data.jl
+++ b/test/data.jl
@@ -2,7 +2,17 @@
 
 @testset "TestData" begin
 
-    @test download(PowerSystems.TestData) |> abspath == joinpath(@__DIR__, "../data") |> abspath
+    force = get(ENV, "PS_FORCE_DOWNLOAD", "false")
+    if force == "true"
+        force = true
+    elseif force == "false"
+        force = false
+    else
+        error("PS_FORCE_DOWNLOAD must be 'true' or 'false'")
+    end
+
+    base = abspath(joinpath(@__DIR__, ".."))
+    directory = download(PowerSystems.TestData; folder=base, force=force) |> abspath
+    @test directory == joinpath(base, "data")
 
 end # testset
-

--- a/test/network_matrices.jl
+++ b/test/network_matrices.jl
@@ -160,14 +160,17 @@ Lodf_5 = [-1.0000 0.3448 0.3071 -1.0000 -1.0000 -0.3071;
         -1.0000 0.3448 0.3071 -1.0000 -1.0000 -0.3071;
         -0.4571 -0.6552 1.0000 -0.4571 -0.4571 -1.0000;]
 
-P5, A5 = PowerSystems.buildptdf(branches5, nodes5);
-P14, A14 = PowerSystems.buildptdf(branches14, nodes14);
-#PRTS = PowerSystems.buildptdf(branches_gmlc, nodes_gmlc)
 
-L5 = PowerSystems.buildlodf(branches5,nodes5) ;
+@time @testset "Network matrices" begin
+    P5, A5 = PowerSystems.buildptdf(branches5, nodes5);
+    @test maximum(P5.data - S5_slackB4) <= 1e-3
 
-maximum(P5.data - S5_slackB4) <= 1e-3
-maximum(P14.data - S14_slackB1) <= 1e-3
-maximum(L5 - Lodf_5) <= 1e-3
-#maximum(PTRS - SRTS_GMLC) <= 1e-6
+    P14, A14 = PowerSystems.buildptdf(branches14, nodes14);
+    @test maximum(P14.data - S14_slackB1) <= 1e-3
 
+    L5 = PowerSystems.buildlodf(branches5,nodes5)
+    @test maximum(L5 - Lodf_5) <= 1e-3
+
+    #PRTS = PowerSystems.buildptdf(branches_gmlc, nodes_gmlc)
+    #@test maximum(PTRS - SRTS_GMLC) <= 1e-6
+end

--- a/test/parse_matpower.jl
+++ b/test/parse_matpower.jl
@@ -1,28 +1,47 @@
-## Matpower files
-files = readdir(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/matpower")))
-file_ext = r".*?\.(\w+)"
+# TODO: Reviewers: Is this a correct list of keys to verify?
+POWER_MODELS_KEYS = [
+    "baseMVA",
+    "branch",
+    "bus",
+    "dcline",
+    "gen",
+    "load",
+    "name",
+    "per_unit",
+    "shunt",
+    "source_type",
+    "source_version",
+    "storage",
+]
 
-if length(files) == 0
-    @error "No test files in the folder"
-end
+@testset "Parse Matpower data files" begin
+    files = [x for x in readdir(joinpath(MATPOWER_DIR)) if splitext(x)[2] == ".m"]
+    if length(files) == 0
+        @error "No test files in the folder"
+    end
 
-for f in files
-    @test_skip try
-        ext = match(file_ext, f)
-        @info "Parsing $f ..."
-        pm_dict = PowerSystems.parse_file(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/matpower",f)))
-        @info "Successfully parsed $f to PowerModels dict"
+    for f in files
+        @info "Parsing $f..."
+        path = joinpath(MATPOWER_DIR, f)
+
+        pm_dict = PowerSystems.parse_file(path)
+        for key in POWER_MODELS_KEYS
+            @test haskey(pm_dict, key)
+        end
+        @info "Successfully parsed $path to PowerModels dict"
+
         PowerSystems.make_mixed_units(pm_dict)
-        @info "Successfully converted $f to mixed_units"
+        @info "Successfully converted $path to mixed_units"
+
         ps_dict = PowerSystems.pm2ps_dict(pm_dict)
-        @info "Successfully parsed $f to PowerSystems dict"
-        Buses, Generators, Storages, Branches, Loads, LoadZones, Shunts, Services = PowerSystems.ps_dict2ps_struct(ps_dict)
-        @info "Successfully parsed $f to PowerSystems devices"
-        sys_test = PowerSystem(Buses, Generators,Loads,Branches,Storages,float(ps_dict["baseMVA"]))
-        @info "Successfully parsed $f to PowerSystem struct"
-        true
-    catch
-        @warn "error while parsing $f"
-        false
+        @info "Successfully parsed $path to PowerSystems dict"
+
+        Buses, Generators, Storages, Branches, Loads, LoadZones, Shunts, Services =
+            PowerSystems.ps_dict2ps_struct(ps_dict)
+        @info "Successfully parsed $path to PowerSystems devices"
+
+        sys_test = PowerSystem(Buses, Generators, Loads, Branches, Storages,
+                               float(ps_dict["baseMVA"]))
+        @info "Successfully parsed $path to PowerSystem struct"
     end
 end

--- a/test/parse_psse.jl
+++ b/test/parse_psse.jl
@@ -1,30 +1,22 @@
-# PSSE Files
-files = readdir(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/psse_raw")))
-file_ext = r".*?\.(\w+)"
+@time @testset "PSSE Parsing " begin
+    files = readdir(PSSE_RAW_DIR)
+    if length(files) == 0
+        @error "No test files in the folder"
+    end
 
-if length(files) == 0
-    @error "No test files in the folder"
-end
-
-for f in files
-    @test_skip @time try
-        ext = match(file_ext, f)
+    for f in files
         @info "Parsing $f ..."
-        pm_dict = PowerSystems.parse_file(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/psse_raw",f)))
+        pm_dict = PowerSystems.parse_file(joinpath(PSSE_RAW_DIR, f))
         @info "Successfully parsed $f to PowerModels dict"
         PowerSystems.make_mixed_units(pm_dict)
         @info "Successfully converted $f to mixed_units"
         ps_dict = PowerSystems.pm2ps_dict(pm_dict)
         @info "Successfully parsed $f to PowerSystems dict"
-        Buses, Generators, Storage, Branches, Loads, LoadZones ,Shunts = PowerSystems.ps_dict2ps_struct(ps_dict)
+        Buses, Generators, Storage, Branches, Loads, LoadZones, Shunts =
+            PowerSystems.ps_dict2ps_struct(ps_dict)
         @info "Successfully parsed $f to PowerSystems devices"
-        sys_test = PowerSystem(Buses, Generators,Loads,Branches,Storage,float(ps_dict["baseMVA"])) # TODO: Add DClines, Shunts
+        sys_test = PowerSystem(Buses, Generators, Loads, Branches, Storage,
+            float(ps_dict["baseMVA"])) # TODO: Add DClines, Shunts
         @info "Successfully parsed $f to PowerSystem struct"
-        true
-    catch
-        @warn "error while parsing $f"
-        false
     end
 end
-
-true

--- a/test/parse_psse.jl
+++ b/test/parse_psse.jl
@@ -1,10 +1,10 @@
 @time @testset "PSSE Parsing " begin
     files = readdir(PSSE_RAW_DIR)
     if length(files) == 0
-        @error "No test files in the folder"
+        error("No test files in the folder")
     end
 
-    for f in files
+    for f in files[1:1]
         @info "Parsing $f ..."
         pm_dict = PowerSystems.parse_file(joinpath(PSSE_RAW_DIR, f))
         @info "Successfully parsed $f to PowerModels dict"
@@ -19,4 +19,9 @@
             float(ps_dict["baseMVA"])) # TODO: Add DClines, Shunts
         @info "Successfully parsed $f to PowerSystem struct"
     end
+
+    # Test bad input
+    pm_dict = PowerSystems.parse_file(joinpath(PSSE_RAW_DIR, files[1]))
+    pm_dict["bus"] = Dict{String, Any}()
+    @test_throws PowerSystems.DataFormatError PowerSystems.pm2ps_dict(pm_dict)
 end

--- a/test/powersystemconstructors.jl
+++ b/test/powersystemconstructors.jl
@@ -1,60 +1,62 @@
+import TimeSeries
 
 include("../data/data_5bus.jl")
 include("../data/data_14bus.jl")
 
-@test try tPowerSystem = PowerSystem(); true finally end
 
-@test try sys5 = PowerSystem(nodes5, generators5, loads5_DA, nothing, nothing,  1000.0); true finally end
-@test try sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  1000.0); true finally end
+@testset "Test PowerSystem constructors" begin
+    tPowerSystem = PowerSystem()
 
-battery5 = [GenericBattery(name = "Bat",
-                status = true,
-                bus = nodes5[2],
-                activepower = 10.0,
-                energy = 5.0,
-                capacity = (min = 0.0, max = 0.0),
-                inputactivepowerlimits = (min = 0.0, max = 50.0),
-                outputactivepowerlimits = (min = 0.0, max = 50.0),
-                efficiency = (in = 0.90, out = 0.80),
-                )];
+    sys5 = PowerSystem(nodes5, generators5, loads5_DA, nothing, nothing,  1000.0)
+    sys5 = PowerSystem(nodes5, generators5, loads5_DA, branches5, nothing,  1000.0)
 
-@test try sys5b = PowerSystem(nodes5, generators5, loads5_DA, nothing, battery5,  1000.0); true finally end
+    battery5=[GenericBattery(name="Bat",
+                             status=true,
+                             bus=nodes5[2],
+                             activepower=10.0,
+                             energy=5.0,
+                             capacity=(min=0.0, max=0.0),
+                             inputactivepowerlimits=(min=0.0, max=50.0),
+                             outputactivepowerlimits=(min=0.0, max=50.0),
+                             efficiency=(in=0.90, out=0.80),
+                            )]
 
-generators_hg5 = [
-    HydroFix("HydroFix",true,nodes5[2],
-        TechHydro(60.0, 15.0, (min = 0.0, max = 60.0), nothing, nothing, nothing, nothing),
-        TimeSeries.TimeArray(DayAhead,solar_ts_DA)
-    ),
-    HydroCurtailment("HydroCurtailment",true,nodes5[3],
-        TechHydro(60.0, 10.0, (min = 0.0, max = 60.0), nothing, nothing, (up = 10.0, down = 10.0), nothing),
-        1000.0,TimeSeries.TimeArray(DayAhead,wind_ts_DA) )
-]
+    sys5b = PowerSystem(nodes5, generators5, loads5_DA, nothing, battery5,  1000.0)
 
-@test try sys5bh = PowerSystem(nodes5, append!(generators5, generators_hg5), loads5_DA, branches5, battery5,  1000.0); true finally end
+    generators_hg5 = [
+        HydroFix("HydroFix", true, nodes5[2],
+                 TechHydro(60.0, 15.0, (min=0.0, max=60.0), nothing, nothing, nothing,
+                           nothing),
+                 TimeSeries.TimeArray(DayAhead, solar_ts_DA)
+        ),
+        HydroCurtailment("HydroCurtailment", true, nodes5[3],
+                         TechHydro(60.0, 10.0, (min=0.0, max=60.0), nothing, nothing,
+                                   (up=10.0, down=10.0), nothing),
+                         1000.0, TimeSeries.TimeArray(DayAhead, wind_ts_DA))
+    ]
 
- #Test Data for 14 Bus
+    sys5bh = PowerSystem(nodes5, append!(generators5, generators_hg5), loads5_DA, branches5,
+                         battery5,  1000.0)
 
-@test try sys14 = PowerSystem(nodes14, generators14, loads14, nothing, nothing,  1000.0); true finally end
-@test try sys14 = PowerSystem(nodes14, generators14, loads14, branches14, nothing,  1000.0); true finally end
+     #Test Data for 14 Bus
 
-battery14 = [GenericBattery(name = "Bat",
-                status = true,
-                bus = nodes14[2],
-                activepower = 10.0,
-                energy = 5.0,
-                capacity = (min = 0.0, max = 0.0),
-                inputactivepowerlimits = (min = 0.0, max = 50.0),
-                outputactivepowerlimits = (min = 0.0, max = 50.0),
-                efficiency = (in = 0.90, out = 0.80),
-                )];
+    sys14 = PowerSystem(nodes14, generators14, loads14, nothing, nothing, 1000.0)
+    sys14 = PowerSystem(nodes14, generators14, loads14, branches14, nothing, 1000.0)
 
+    battery14 = [GenericBattery(name="Bat",
+                                status=true,
+                                bus=nodes14[2],
+                                activepower=10.0,
+                                energy=5.0,
+                                capacity=(min=0.0, max=0.0),
+                                inputactivepowerlimits=(min=0.0, max=50.0),
+                                outputactivepowerlimits=(min=0.0, max=50.0),
+                                efficiency=(in=0.90, out=0.80),
+                               )]
 
+    sys14b = PowerSystem(nodes14, generators14, loads14, nothing, battery14, 1000.0)
+    sys14b = PowerSystem(nodes14, generators14, loads14, branches14, battery14, 1000.0)
 
-
-@test try sys14b = PowerSystem(nodes14, generators14, loads14, nothing, battery14,  1000.0); true finally end
-@test try sys14b = PowerSystem(nodes14, generators14, loads14, branches14, battery14,  1000.0); true finally end
-
-@test try 
-    ps_dict = PowerSystems.parsestandardfiles(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/matpower/case5_re.m")));
+    ps_dict = PowerSystems.parsestandardfiles(joinpath(MATPOWER_DIR, "case5_re.m"))
     sys = PowerSystems.PowerSystem(ps_dict)
-true finally end
+end

--- a/test/readforecastdata.jl
+++ b/test/readforecastdata.jl
@@ -1,36 +1,46 @@
-@test try
-        ps_dict = PowerSystems.parsestandardfiles(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/matpower/case5_re.m")));
-        da_time_series = PowerSystems.read_data_files(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/forecasts/5bus_ts")); REGEX_FILE = r"da_(.*?)\.csv");
-        rt_time_series = PowerSystems.read_data_files(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/forecasts/5bus_ts")); REGEX_FILE = r"rt_(.*?)\.csv");
-        ps_dict = PowerSystems.assign_ts_data(ps_dict,rt_time_series);
+@testset "Forecast data" begin
+    ps_dict = PowerSystems.parsestandardfiles(joinpath(MATPOWER_DIR, "case5_re.m"))
+    da_time_series = PowerSystems.read_data_files(joinpath(FORECASTS_DIR, "5bus_ts");
+                                                  REGEX_FILE=r"da_(.*?)\.csv")
+    rt_time_series = PowerSystems.read_data_files(joinpath(FORECASTS_DIR, "5bus_ts");
+                                                  REGEX_FILE=r"rt_(.*?)\.csv")
+    ps_dict = PowerSystems.assign_ts_data(ps_dict,rt_time_series)
 
-        buses, generators, storage, branches, loads, loadZones, shunts, services  = PowerSystems.ps_dict2ps_struct(ps_dict);
-        sys_5 = PowerSystems.PowerSystem(buses, generators, loads, branches, storage, ps_dict["baseMVA"]);
+    buses, generators, storage, branches, loads, loadZones, shunts, services =
+        PowerSystems.ps_dict2ps_struct(ps_dict)
+    sys_5 = PowerSystems.PowerSystem(buses, generators, loads, branches, storage,
+                                     ps_dict["baseMVA"])
 
-        forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"], Dates.Day(1), 24, generators);
-        forecast_load = PowerSystems.make_forecast_dict(da_time_series, Dates.Day(1), 24, loads);
+    forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"],
+                                                   Dates.Day(1), 24, generators)
+    forecast_load = PowerSystems.make_forecast_dict(da_time_series, Dates.Day(1), 24, loads)
+    forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"], Dates.Day(1), 24,
+                                                   generators)
+    forecast_load = PowerSystems.make_forecast_dict(da_time_series, Dates.Day(1), 24, loads)
+    forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"], Dates.Day(1), 24,
+                                                   generators);
+    forecast_load = PowerSystems.make_forecast_dict(da_time_series, Dates.Day(1), 24,
+                                                    loads);
 
-        forecast_struct = PowerSystems.make_forecast_array(forecast_gen);
-        true
-    finally
-        false
-    end
 
-@test try
-        ps_dict = PowerSystems.parsestandardfiles(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/matpower/RTS_GMLC.m")));
-        da_time_series = PowerSystems.read_data_files(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/forecasts/RTS_GMLC_forecasts")); REGEX_FILE = r"DAY_AHEAD(.*?)\.csv");
-        rt_time_series = PowerSystems.read_data_files(abspath(joinpath(dirname(Base.find_package("PowerSystems")), "../data/forecasts/RTS_GMLC_forecasts")); REGEX_FILE = r"REAL_TIME(.*?)\.csv");
-        ps_dict = PowerSystems.assign_ts_data(ps_dict,rt_time_series);
+    ps_dict = PowerSystems.parsestandardfiles(joinpath(MATPOWER_DIR, "RTS_GMLC.m"))
+    da_time_series = PowerSystems.read_data_files(joinpath(FORECASTS_DIR,
+                                                           "RTS_GMLC_forecasts");
+                                                  REGEX_FILE=r"DAY_AHEAD(.*?)\.csv")
+    rt_time_series = PowerSystems.read_data_files(joinpath(FORECASTS_DIR,
+                                                           "RTS_GMLC_forecasts");
+                                                  REGEX_FILE=r"REAL_TIME(.*?)\.csv")
+    ps_dict = PowerSystems.assign_ts_data(ps_dict,rt_time_series)
 
-        buses, generators, storage, branches, loads, loadZones, shunts, services  = PowerSystems.ps_dict2ps_struct(ps_dict);
-        sys_5 = PowerSystems.PowerSystem(buses, generators, loads, branches, storage, ps_dict["baseMVA"]);
+    buses, generators, storage, branches, loads, loadZones, shunts, services =
+        PowerSystems.ps_dict2ps_struct(ps_dict)
+    sys_5 = PowerSystems.PowerSystem(buses, generators, loads, branches, storage,
+                                     ps_dict["baseMVA"])
 
-        forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"], Dates.Day(1), 24, generators);
-        forecast_load = PowerSystems.make_forecast_dict(rt_time_series, Dates.Day(1), 288, loads, loadZones);
+    forecast_gen = PowerSystems.make_forecast_dict(da_time_series["gen"],
+                                                   Dates.Day(1), 24, generators);
+    forecast_load = PowerSystems.make_forecast_dict(rt_time_series, Dates.Day(1),
+                                                    288, loads, loadZones)
 
-        forecast_struct = PowerSystems.make_forecast_array(forecast_load);
-        true
-    finally
-        false
-    end
-true
+    forecast_struct = PowerSystems.make_forecast_array(forecast_load)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,15 @@ using Dates
 
 using PowerSystems
 
-include("data.jl")
 
-BASE_DIR = joinpath(dirname(Base.find_package("PowerSystems")), "..")
+BASE_DIR = abspath(joinpath(dirname(Base.find_package("PowerSystems")), ".."))
 DATA_DIR = joinpath(BASE_DIR, "data")
 FORECASTS_DIR = joinpath(DATA_DIR, "forecasts")
 MATPOWER_DIR = joinpath(DATA_DIR, "matpower")
 PSSE_RAW_DIR = joinpath(DATA_DIR, "psse_raw")
 RTS_GMLC_DIR = joinpath(DATA_DIR, "RTS_GMLC")
+
+download(PowerSystems.TestData)
 
 LOG_LEVELS = Dict(
     "Debug" => Logging.Debug,
@@ -60,7 +61,12 @@ macro includetests(testarg...)
 end
 
 gl = global_logger()
-global_logger(ConsoleLogger(gl.stream, LOG_LEVELS[get(ENV, "PS_LOG_LEVEL", "Error")]))
+level = get(ENV, "PS_LOG_LEVEL", "Error")
+log_level = get(LOG_LEVELS, level, nothing)
+if log_level == nothing
+    error("Invalid log level $level: Supported levels: $(values(LOG_LEVELS))")
+end
+global_logger(ConsoleLogger(gl.stream, log_level))
 
 # Testing Topological components of the schema
 @testset "Begin PowerSystems tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,52 +1,68 @@
-using PowerSystems
 using Test
 using Logging
 using Dates
 
-# Testing Topological components of the schema
-gl = global_logger()
-global_logger(ConsoleLogger(gl.stream, Logging.Error))
+using PowerSystems
 
 include("data.jl")
 
-@testset "Check PowerSystems Data" begin
-    @info "Check bus index"
-    include("busnumberchecks.jl")
+BASE_DIR = joinpath(dirname(Base.find_package("PowerSystems")), "..")
+DATA_DIR = joinpath(BASE_DIR, "data")
+FORECASTS_DIR = joinpath(DATA_DIR, "forecasts")
+MATPOWER_DIR = joinpath(DATA_DIR, "matpower")
+PSSE_RAW_DIR = joinpath(DATA_DIR, "psse_raw")
+RTS_GMLC_DIR = joinpath(DATA_DIR, "RTS_GMLC")
+
+LOG_LEVELS = Dict(
+    "Debug" => Logging.Debug,
+    "Info" => Logging.Info,
+    "Warn" => Logging.Warn,
+    "Error" => Logging.Error,
+)
+
+
+"""
+Copied @includetests from https://github.com/ssfrr/TestSetExtensions.jl.
+Ideally, we could import and use TestSetExtensions.  Its functionality was broken by changes
+in Julia v0.7.  Refer to https://github.com/ssfrr/TestSetExtensions.jl/pull/7.
+"""
+
+"""
+Includes the given test files, given as a list without their ".jl" extensions.
+If none are given it will scan the directory of the calling file and include all
+the julia files.
+"""
+macro includetests(testarg...)
+    if length(testarg) == 0
+        tests = []
+    elseif length(testarg) == 1
+        tests = testarg[1]
+    else
+        error("@includetests takes zero or one argument")
+    end
+
+    quote
+        tests = $tests
+        rootfile = @__FILE__
+        if length(tests) == 0
+            tests = readdir(dirname(rootfile))
+            tests = filter(f->endswith(f, ".jl") && f != basename(rootfile), tests)
+        else
+            tests = map(f->string(f, ".jl"), tests)
+        end
+        println()
+        for test in tests
+            print(splitext(test)[1], ": ")
+            include(test)
+            println()
+        end
+    end
 end
 
-@testset "Read PowerSystems data" begin
-    @info "Read Data in *.jl files"
-    include("readnetworkdata.jl")
-end
+gl = global_logger()
+global_logger(ConsoleLogger(gl.stream, LOG_LEVELS[get(ENV, "PS_LOG_LEVEL", "Error")]))
 
-@testset "Local Functions" begin
-    @info "Test all the constructors"
-    include("constructors.jl")
-    @info "Test PowerSystem constructor"
-    include("powersystemconstructors.jl")
-end
-
-@testset "Utilities testing" begin
-    @info "Testing Network Matrices"
-    @test @time include("network_matrices.jl")
-    @info "Testing Line Check Functions"
-    include("branchchecks_testing.jl")
-end
-
-@testset "Forecast parsing" begin
-    @info "Reading forecast data "
-    @time include("readforecastdata.jl")
-end
-
-@testset "Parsing Code" begin
-    @info "Parsing Matpower"
-    include("parse_matpower.jl")
-    @info "Parsing PSSe"
-    include("parse_psse.jl")
-    @info "Parsing CDM"
-    include("cdmparse.jl")
-end
-
-@testset "Print testing" begin
-    include("printing.jl");
+# Testing Topological components of the schema
+@testset "Begin PowerSystems tests" begin
+    @includetests ARGS
 end


### PR DESCRIPTION
All unit tests now run and pass.

This pull request also has a few UT-execution enhancements:

- Instead of explicitly including all tests runtests.jl now automatically runs all "*.jl" in the test directory.
- You can now iterate on one or more unit tests by pushing a test name into ARGS while in the REPL.
  - push!(ARGS, "parse_psse")
  - include("test/runtests.jl")
- You can customize logging verbosity by setting the environment variable PS_LOG_LEVEL to Debug, Info, Warn, or Error.

You will also notice a different in unit test output.  When all tests pass it will show the total number of tests in PowerSystems.  If any test fails then it will print out a summary table showing the results of each test.  The difference is because of a top-level @testset statement that I added in runtests.jl.