### PR TITLE
implemented a generator-mapping config file

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -216,14 +216,6 @@ git-tree-sha1 = "435707791dc85a67d98d671c1c3fcf1b20b00f94"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 version = "0.29.0"
 
-[[TOML]]
-deps = ["Dates"]
-git-tree-sha1 = "e9fd97ec8b0cf1ffa41a3ab9c27296dbb8797125"
-repo-rev = "3064b9660627539a6ae0609099ede7099e044d3a"
-repo-url = "https://github.com/wildart/TOML.jl"
-uuid = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
-version = "0.4.0"
-
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions", "Test"]
 git-tree-sha1 = "eba4b1d0a82bdd773307d652c6e5f8c82104c676"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -33,6 +33,12 @@ git-tree-sha1 = "36bbf5374c661054d41410dc53ff752972583b9b"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.5.2"
 
+[[Codecs]]
+deps = ["Test"]
+git-tree-sha1 = "70885e5e038cba1c4c17a84ad6c40756e10a4fb5"
+uuid = "19ecbf4d-ef7c-5e4b-b54a-0a0ff23c5aed"
+version = "0.5.0"
+
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
 git-tree-sha1 = "ec61a16eed883ad0cfa002d7489b3ce6d039bb9a"
@@ -135,9 +141,9 @@ version = "1.0.2"
 
 [[Parsers]]
 deps = ["Dates", "Mmap", "Test", "WeakRefStrings"]
-git-tree-sha1 = "dc0469396c9b221223861558ad89141be38635b4"
+git-tree-sha1 = "d4e634c9cab597f0ec8f5a1d62c0787e98602c55"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.2.20"
+version = "0.2.22"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -256,3 +262,9 @@ deps = ["Missings", "Random", "Test"]
 git-tree-sha1 = "960639a12ffd223ee463e93392aeb260fa325566"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 version = "0.5.8"
+
+[[YAML]]
+deps = ["Codecs", "Compat"]
+git-tree-sha1 = "3bde77cee95cce0c0b9b18813d85e18e8ed4f415"
+uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+version = "0.3.2"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -29,9 +29,9 @@ version = "0.5.2"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
-git-tree-sha1 = "e3df104c84dfc108f0ca203fd7f5bbdc98641ae9"
+git-tree-sha1 = "36bbf5374c661054d41410dc53ff752972583b9b"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.5.1"
+version = "0.5.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
@@ -135,9 +135,9 @@ version = "1.0.2"
 
 [[Parsers]]
 deps = ["Dates", "Mmap", "Test", "WeakRefStrings"]
-git-tree-sha1 = "400aaa49532991f8e31d13f87c6eeaeee83663d4"
+git-tree-sha1 = "dc0469396c9b221223861558ad89141be38635b4"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.2.16"
+version = "0.2.20"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -212,9 +212,17 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsBase]]
 deps = ["DataStructures", "DelimitedFiles", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
-git-tree-sha1 = "7b596062316c7d846b67bf625d5963a832528598"
+git-tree-sha1 = "435707791dc85a67d98d671c1c3fcf1b20b00f94"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.27.0"
+version = "0.29.0"
+
+[[TOML]]
+deps = ["Dates"]
+git-tree-sha1 = "e9fd97ec8b0cf1ffa41a3ab9c27296dbb8797125"
+repo-rev = "3064b9660627539a6ae0609099ede7099e044d3a"
+repo-url = "https://github.com/wildart/TOML.jl"
+uuid = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
+version = "0.4.0"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions", "Test"]
@@ -223,10 +231,10 @@ uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 version = "0.4.1"
 
 [[Tables]]
-deps = ["IteratorInterfaceExtensions", "Requires", "TableTraits", "Test"]
-git-tree-sha1 = "89f8fde6394579580fb75088e45ad95551199c7c"
+deps = ["IteratorInterfaceExtensions", "LinearAlgebra", "Requires", "TableTraits", "Test"]
+git-tree-sha1 = "719d5be11e89ae29d79b469c4238b63b53544d38"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "0.1.14"
+version = "0.1.18"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -240,9 +248,9 @@ version = "0.14.0"
 
 [[TranscodingStreams]]
 deps = ["Pkg", "Random", "Test"]
-git-tree-sha1 = "a34a2d588e2d2825602bf14a24216d5c8b0921ec"
+git-tree-sha1 = "d4718bd4db6b7850af3c3833556c6aedbb8e9904"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.8.1"
+version = "0.9.2"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -253,6 +261,6 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[WeakRefStrings]]
 deps = ["Missings", "Random", "Test"]
-git-tree-sha1 = "1a9511b00152bbecaf3cd59d1fadd5d23e7bb1f9"
+git-tree-sha1 = "960639a12ffd223ee463e93392aeb260fa325566"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
-version = "0.5.4"
+version = "0.5.8"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+TOML = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-TOML = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [extras]

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -89,7 +89,7 @@ import TimeSeries
 import DataFrames
 import JSON
 import CSV
-import Pkg.TOML
+import YAML
 
 #################################################################################
 # Includes

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -89,7 +89,7 @@ import TimeSeries
 import DataFrames
 import JSON
 import CSV
-import TOML
+import Pkg.TOML
 
 #################################################################################
 # Includes

--- a/src/PowerSystems.jl
+++ b/src/PowerSystems.jl
@@ -89,6 +89,7 @@ import TimeSeries
 import DataFrames
 import JSON
 import CSV
+import TOML
 
 #################################################################################
 # Includes

--- a/src/base.jl
+++ b/src/base.jl
@@ -27,7 +27,7 @@ PowerSystem(file, ts_folder; kwargs...)
 # Keyword arguments
 
 * `runchecks`::Bool : run available checks on input fields
-DOCTODO: any other keyword arguments?
+DOCTODO: any other keyword arguments? genmap_file, REGEX_FILE
 
 """
 struct PowerSystem{L <: ElectricLoad,
@@ -187,11 +187,9 @@ function PowerSystem(ps_dict::Dict{String,Any}; kwargs...)
         return sys
 end
 
-# DOCTODO: genmap_file argument not yet in constructor docstring above
-function PowerSystem(file::String, ts_folder::String;
-                     genmap_file::Union{String,Nothing}=nothing, kwargs...)
+function PowerSystem(file::String, ts_folder::String; kwargs...)
     
-    ps_dict = parsestandardfiles(file,ts_folder; genmap_file=genmap_file, kwargs...)
+    ps_dict = parsestandardfiles(file,ts_folder; kwargs...)
     Buses, Generators, Storage, Branches, Loads, LoadZones, Shunts, Services =
         ps_dict2ps_struct(ps_dict)
     sys = PowerSystem(Buses, Generators, Loads, Branches, Storage, ps_dict["baseMVA"];

--- a/src/base.jl
+++ b/src/base.jl
@@ -187,11 +187,15 @@ function PowerSystem(ps_dict::Dict{String,Any}; kwargs...)
         return sys
 end
 
-function PowerSystem(file::String, ts_folder::String; kwargs...)
+# DOCTODO: genmap_file argument not yet in constructor docstring above
+function PowerSystem(file::String, ts_folder::String;
+                     genmap_file::Union{String,Nothing}=nothing, kwargs...)
+    
+    ps_dict = parsestandardfiles(file,ts_folder; genmap_file=genmap_file, kwargs...)
+    Buses, Generators, Storage, Branches, Loads, LoadZones, Shunts, Services =
+        ps_dict2ps_struct(ps_dict)
+    sys = PowerSystem(Buses, Generators, Loads, Branches, Storage, ps_dict["baseMVA"];
+                      kwargs...);
 
-        ps_dict = parsestandardfiles(file,ts_folder; kwargs...)
-        Buses, Generators, Storage, Branches, Loads, LoadZones, Shunts, Services = ps_dict2ps_struct(ps_dict)
-        sys = PowerSystem(Buses, Generators,Loads,Branches,Storage,ps_dict["baseMVA"]; kwargs...);
-
-        return sys
+    return sys
 end

--- a/src/parsers/generator_mapping.toml
+++ b/src/parsers/generator_mapping.toml
@@ -1,0 +1,22 @@
+# Default configuration file for mapping generator fuel and type strings to
+# generator categories in PowerSystems. All mapping strings should be in
+# uppercase because that is what is assumed in read_gen().
+
+[Hydro]
+fuel = ["HYDRO"]
+type = ["HYDRO", "HY"]
+
+[WIND]
+fuel = ["WIND"]
+type = ["WIND", "W2"]
+
+[PV]
+fuel = ["SOLAR", "PV"]
+type = ["PV"]
+
+[RTPV]
+fuel = ["SOLAR", "PV"]
+type = ["RTPV"]
+
+# right now, everything else is classified as thermal, but could create
+# mappings for other types if needed/wanted

--- a/src/parsers/generator_mapping.yaml
+++ b/src/parsers/generator_mapping.yaml
@@ -2,21 +2,21 @@
 # generator categories in PowerSystems. All mapping strings should be in
 # uppercase because that is what is assumed in read_gen().
 
-[Hydro]
-fuel = ["HYDRO"]
-type = ["HYDRO", "HY"]
+Hydro:
+ fuel: [HYDRO]
+ type: [HYDRO, HY]
 
-[WIND]
-fuel = ["WIND"]
-type = ["WIND", "W2"]
+WIND:
+ fuel: [WIND]
+ type: [WIND, W2]
 
-[PV]
-fuel = ["SOLAR", "PV"]
-type = ["PV"]
+PV:
+ fuel: [SOLAR, PV]
+ type: [PV]
 
-[RTPV]
-fuel = ["SOLAR", "PV"]
-type = ["RTPV"]
+RTPV:
+ fuel: [SOLAR, PV]
+ type: [RTPV]
 
 # right now, everything else is classified as thermal, but could create
 # mappings for other types if needed/wanted

--- a/src/parsers/im_io/matlab.jl
+++ b/src/parsers/im_io/matlab.jl
@@ -61,7 +61,7 @@ function parse_matlab_string(data_string::String; extended=false)
                 matlab_dict[name] = value
             end
         else
-            @error "Matlab parser skipping the following line:\n  $(line)"
+            @error "Matlab parser skipping line number $(index) consisting of:\n  $(line)"
         end
 
         index += 1

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -272,9 +272,11 @@ function read_gen(data, Buses; kwargs...)
         genmap_file = kwargs[:genmap_file]
     else # use default generator mapping config file
         genmap_file = joinpath(dirname(dirname(pathof(PowerSystems))),
-                               "src/parsers/generator_mapping.toml")
+                               "src/parsers/generator_mapping.yaml")
     end
-    genmap_dict = TOML.parsefile(genmap_file) 
+    genmap_dict = open(genmap_file) do file
+        YAML.load(file)
+    end
     
     generators = Dict{String,Any}()
     generators["Thermal"] = Dict{String,Any}()

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -6,7 +6,7 @@ Takes a dictionary parsed by PowerModels and returns a PowerSystems
 dictionary.  Currently Supports MATPOWER and PSSE data files parsed by
 PowerModels
 """
-function pm2ps_dict(data::Dict{String,Any})
+function pm2ps_dict(data::Dict{String,Any}, genmap_file::Union{String,Nothing}=nothing)
     if length(data["bus"]) < 1
         throw(DataFormatError("There are no buses in this file."))
     end
@@ -25,7 +25,7 @@ function pm2ps_dict(data::Dict{String,Any})
     Loads= read_loads(data,ps_dict["bus"])
     LoadZones= read_loadzones(data,ps_dict["bus"])
     @info "Reading generator data"
-    Generators= read_gen(data, ps_dict["bus"])
+    Generators= read_gen(data, ps_dict["bus"], genmap_file)
     @info "Reading branch data"
     Branches= read_branch(data,ps_dict["bus"])
     Shunts = read_shunt(data,ps_dict["bus"])
@@ -266,13 +266,13 @@ end
 """
 Transfer generators to ps_dict according to their classification
 """
-function read_gen(data, Buses, genmap_file=nothing)
+function read_gen(data, Buses, genmap_file::Union{String,Nothing})
 
     if genmap_file == nothing
         genmap_file = joinpath(dirname(dirname(pathof(PowerSystems))),
                                "src/parsers/generator_mapping.toml")
     end
-    genmap_dict = TOML.parsefile(genmap_file) # not working... map to current path??
+    genmap_dict = TOML.parsefile(genmap_file) 
     
     Generators = Dict{String,Any}()
     Generators["Thermal"] = Dict{String,Any}()

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -277,9 +277,24 @@ function read_gen(data,Buses)
         gen_name =[]
         type_gen =[]
         for (d_key,d) in data["gen"]
-            haskey(d,"fuel") ? fuel =d["fuel"] : haskey(data,"genfuel") ? fuel = data["genfuel"][d_key]["col_1"] : fuel = "generic"
-            haskey(d,"type") ? type_gen = d["type"] : haskey(data,"gentype") ? type_gen = data["gentype"][d_key]["col_1"] : type_gen = "generic"
-            haskey(d,"name") ? gen_name = d["name"] : haskey(d,"source_id") ? gen_name = strip(string(d["source_id"][1])*"-"*d["source_id"][2]) : gen_name = d_key
+
+            if haskey(d,"fuel")
+                fuel = d["fuel"]
+            else
+                fuel = "generic"
+            end
+            if haskey(d,"type") 
+                type_gen = d["type"]
+            else
+                type_gen = "generic"
+            end
+            if haskey(d,"name")
+                gen_name = d["name"]
+            elseif haskey(d,"source_id")
+                gen_name = strip(string(d["source_id"][1])*"-"*d["source_id"][2])
+            else
+                gen_name = d_key
+            end
 
             if uppercase(fuel) in ["HYDRO"] || uppercase(type_gen) in ["HYDRO","HY"]
                 bus = find_bus(Buses,d)

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -276,14 +276,14 @@ function read_gen(data, Buses; kwargs...)
     end
     genmap_dict = TOML.parsefile(genmap_file) 
     
-    Generators = Dict{String,Any}()
-    Generators["Thermal"] = Dict{String,Any}()
-    Generators["Hydro"] = Dict{String,Any}()
-    Generators["Renewable"] = Dict{String,Any}()
-    Generators["Renewable"]["PV"]= Dict{String,Any}()
-    Generators["Renewable"]["RTPV"]= Dict{String,Any}()
-    Generators["Renewable"]["WIND"]= Dict{String,Any}()
-    Generators["Storage"] = Dict{String,Any}() # not currently used? JJS 3/13/19
+    generators = Dict{String,Any}()
+    generators["Thermal"] = Dict{String,Any}()
+    generators["Hydro"] = Dict{String,Any}()
+    generators["Renewable"] = Dict{String,Any}()
+    generators["Renewable"]["PV"]= Dict{String,Any}()
+    generators["Renewable"]["RTPV"]= Dict{String,Any}()
+    generators["Renewable"]["WIND"]= Dict{String,Any}()
+    generators["Storage"] = Dict{String,Any}() # not currently used? JJS 3/13/19
     
     if !haskey(data, "gen")
         return nothing
@@ -307,11 +307,11 @@ function read_gen(data, Buses; kwargs...)
         bus = find_bus(Buses, d)
 
         assigned = false 
-        for (rkey, rval) in Generators["Renewable"]
+        for (rkey, rval) in generators["Renewable"]
             fuelkeys = genmap_dict[rkey]["fuel"]
             typekeys = genmap_dict[rkey]["type"]
             if fuel in fuelkeys && type_gen in typekeys
-                Generators["Renewable"][rkey][gen_name] = make_ren_gen(gen_name, d, bus)
+                generators["Renewable"][rkey][gen_name] = make_ren_gen(gen_name, d, bus)
                 assigned = true
                 break
             end
@@ -320,18 +320,18 @@ function read_gen(data, Buses; kwargs...)
             fuelkeys = genmap_dict["Hydro"]["fuel"]
             typekeys = genmap_dict["Hydro"]["type"]
             if fuel in fuelkeys && type_gen in typekeys
-                Generators["Hydro"][gen_name] = make_hydro_gen(gen_name, d, bus)
+                generators["Hydro"][gen_name] = make_hydro_gen(gen_name, d, bus)
                 assigned = true
             end
         end
         if !assigned
             # default to Thermal type if not already assigned
-            Generators["Thermal"][gen_name] = make_thermal_gen(gen_name, d, bus)
+            generators["Thermal"][gen_name] = make_thermal_gen(gen_name, d, bus)
         end
 
     end # for (d_key,d) in data["gen"]
 
-    return Generators
+    return generators
 end
 
 function make_transformer(b_name, d, bus_f, bus_t)

--- a/src/parsers/pm2ps_parser.jl
+++ b/src/parsers/pm2ps_parser.jl
@@ -6,7 +6,7 @@ Takes a dictionary parsed by PowerModels and returns a PowerSystems
 dictionary.  Currently Supports MATPOWER and PSSE data files parsed by
 PowerModels
 """
-function pm2ps_dict(data::Dict{String,Any}, genmap_file::Union{String,Nothing}=nothing)
+function pm2ps_dict(data::Dict{String,Any}; kwargs...)
     if length(data["bus"]) < 1
         throw(DataFormatError("There are no buses in this file."))
     end
@@ -25,7 +25,7 @@ function pm2ps_dict(data::Dict{String,Any}, genmap_file::Union{String,Nothing}=n
     Loads= read_loads(data,ps_dict["bus"])
     LoadZones= read_loadzones(data,ps_dict["bus"])
     @info "Reading generator data"
-    Generators= read_gen(data, ps_dict["bus"], genmap_file)
+    Generators= read_gen(data, ps_dict["bus"]; kwargs...)
     @info "Reading branch data"
     Branches= read_branch(data,ps_dict["bus"])
     Shunts = read_shunt(data,ps_dict["bus"])
@@ -266,9 +266,11 @@ end
 """
 Transfer generators to ps_dict according to their classification
 """
-function read_gen(data, Buses, genmap_file::Union{String,Nothing})
+function read_gen(data, Buses; kwargs...)
 
-    if genmap_file == nothing
+    if :genmap_file in keys(kwargs)
+        genmap_file = kwargs[:genmap_file]
+    else # use default generator mapping config file
         genmap_file = joinpath(dirname(dirname(pathof(PowerSystems))),
                                "src/parsers/generator_mapping.toml")
     end

--- a/src/parsers/pm_io/common.jl
+++ b/src/parsers/pm_io/common.jl
@@ -15,6 +15,9 @@ function parse_file(file::String; import_all=false, validate=true)
         pm_data = parse_json(file, validate=validate)
     end
 
+    # TODO:  not sure if this relevant for all three file types, or only .m, JJS 3/7/19
+    move_genfuel_and_gentype!(pm_data)
+
     return pm_data
 end
 

--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -1802,21 +1802,22 @@ end
 Move gentype and genfuel fields to be subfields of gen
 """
 function move_genfuel_and_gentype!(data::Dict{String,Any})
-    ## this is not modifying the dict in place! how to do that?
+    ngen = length(data["gen"])
     
-    if haskey(data, "genfuel")
-        # presume that genfuel length equals gen length -- do we need to check?
-        for (key,val) in data["genfuel"]
-            data["gen"][key]["fuel"] = val["col_1"]
+    toplevkeys = ("genfuel", "gentype")
+    sublevkeys = ("fuel", "type")
+    for i in range(1, stop=2)
+        if haskey(data, toplevkeys[i])
+            # check that lengths of category and generators match
+            if length(data[toplevkeys[i]]) != ngen
+                str = toplevkeys[i]
+                throw("length of $str does not equal the number of generators")
+            end
+            for (key,val) in data[toplevkeys[i]]
+                data["gen"][key][sublevkeys[i]] = val["col_1"]
+            end
+            delete!(data, toplevkeys[i])        
         end
     end
-    delete!(data, "genfuel")
-    if haskey(data, "gentype") 
-        # presume that genfuel length equals gen length -- do we need to check?
-        for (key,val) in data["gentype"]
-            data["gen"][key]["type"] = val["col_1"]
-        end
-    end
-    delete!(data, "gentype")
     
 end

--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -1796,3 +1796,27 @@ function _make_multiconductor(data::Dict{String,Any}, conductors::Real)
         end
     end
 end
+
+
+"""
+Move gentype and genfuel fields to be subfields of gen
+"""
+function move_genfuel_and_gentype!(data::Dict{String,Any})
+    ## this is not modifying the dict in place! how to do that?
+    
+    if haskey(data, "genfuel")
+        # presume that genfuel length equals gen length -- do we need to check?
+        for (key,val) in data["genfuel"]
+            data["gen"][key]["fuel"] = val["col_1"]
+        end
+    end
+    delete!(data, "genfuel")
+    if haskey(data, "gentype") 
+        # presume that genfuel length equals gen length -- do we need to check?
+        for (key,val) in data["gentype"]
+            data["gen"][key]["type"] = val["col_1"]
+        end
+    end
+    delete!(data, "gentype")
+    
+end

--- a/src/parsers/pm_io/data.jl
+++ b/src/parsers/pm_io/data.jl
@@ -1806,12 +1806,13 @@ function move_genfuel_and_gentype!(data::Dict{String,Any})
     
     toplevkeys = ("genfuel", "gentype")
     sublevkeys = ("fuel", "type")
-    for i in range(1, stop=2)
+    for i in range(1, stop=length(toplevkeys))
         if haskey(data, toplevkeys[i])
             # check that lengths of category and generators match
             if length(data[toplevkeys[i]]) != ngen
                 str = toplevkeys[i]
-                throw("length of $str does not equal the number of generators")
+                throw(DataFormatError(
+                    "length of $str does not equal the number of generators"))
             end
             for (key,val) in data[toplevkeys[i]]
                 data["gen"][key][sublevkeys[i]] = val["col_1"]

--- a/src/parsers/standardfiles_parser.jl
+++ b/src/parsers/standardfiles_parser.jl
@@ -3,7 +3,7 @@
 Read in power-system parameters from a Matpower, PTI, or JSON file and do some
 data checks.
 """
-function parsestandardfiles(file::String; genmap_file::Union{String,Nothing}=nothing)
+function parsestandardfiles(file::String; kwargs...)
 
     # function `parse_file` is in pm_io/common.jl
     data = parse_file(file)
@@ -17,23 +17,22 @@ function parsestandardfiles(file::String; genmap_file::Union{String,Nothing}=not
     end
 
     # in pm2ps_parser.jl
-    data = pm2ps_dict(data, genmap_file)
+    data = pm2ps_dict(data; kwargs...)
 
     return data
 
 end
 
     
-function parsestandardfiles(file::String, ts_folder::String;
-                            genmap_file::Union{String,Nothing}=nothing, kwargs...)
+function parsestandardfiles(file::String, ts_folder::String; kwargs...)
 
     # TODO: assert a naming convention
-    data = parsestandardfiles(file, genmap_file=genmap_file)
+    data = parsestandardfiles(file; kwargs...)
 
     ts_data = read_data_files(ts_folder; kwargs...)
 
     # assign_ts_data is in forecast_parser.jl
-    data = assign_ts_data(data,ts_data)
+    data = assign_ts_data(data, ts_data)
 
     return data
 end

--- a/src/parsers/standardfiles_parser.jl
+++ b/src/parsers/standardfiles_parser.jl
@@ -3,8 +3,7 @@
 Read in power-system parameters from a Matpower, PTI, or JSON file and do some
 data checks.
 """
-function parsestandardfiles(file::String, genmap_file::Union{String,Nothing}=nothing,
-                            ts_folder::Union{String,Nothing}=nothing; kwargs...)
+function parsestandardfiles(file::String; genmap_file::Union{String,Nothing}=nothing)
 
     # function `parse_file` is in pm_io/common.jl
     data = parse_file(file)
@@ -20,26 +19,21 @@ function parsestandardfiles(file::String, genmap_file::Union{String,Nothing}=not
     # in pm2ps_parser.jl
     data = pm2ps_dict(data, genmap_file)
 
-    if ts_folder!=nothing
-        ts_data = read_data_files(ts_folder; kwargs...)
-        # assign_ts_data is in forecast_parser.jl
-        data = assign_ts_data(data,ts_data)
-    end
-    
     return data
 
 end
 
     
-# function parsestandardfiles(file::String, ts_folder::String; kwargs...)
+function parsestandardfiles(file::String, ts_folder::String;
+                            genmap_file::Union{String,Nothing}=nothing, kwargs...)
 
-#     # TODO: assert a naming convention
-#     data = parsestandardfiles(file)
+    # TODO: assert a naming convention
+    data = parsestandardfiles(file, genmap_file=genmap_file)
 
-#     ts_data = read_data_files(ts_folder; kwargs...)
+    ts_data = read_data_files(ts_folder; kwargs...)
 
-#     # assign_ts_data is in forecast_parser.jl
-#     data = assign_ts_data(data,ts_data)
+    # assign_ts_data is in forecast_parser.jl
+    data = assign_ts_data(data,ts_data)
 
-#     return data
-# end
+    return data
+end

--- a/src/parsers/standardfiles_parser.jl
+++ b/src/parsers/standardfiles_parser.jl
@@ -1,8 +1,10 @@
+# TODO: assert a naming convention -- ??
 """
 Read in power-system parameters from a Matpower, PTI, or JSON file and do some
 data checks.
 """
-function parsestandardfiles(file::String)
+function parsestandardfiles(file::String, genmap_file::Union{String,Nothing}=nothing,
+                            ts_folder::Union{String,Nothing}=nothing; kwargs...)
 
     # function `parse_file` is in pm_io/common.jl
     data = parse_file(file)
@@ -16,21 +18,28 @@ function parsestandardfiles(file::String)
     end
 
     # in pm2ps_parser.jl
-    data = pm2ps_dict(data)
+    data = pm2ps_dict(data, genmap_file)
 
+    if ts_folder!=nothing
+        ts_data = read_data_files(ts_folder; kwargs...)
+        # assign_ts_data is in forecast_parser.jl
+        data = assign_ts_data(data,ts_data)
+    end
+    
     return data
 
 end
 
-function parsestandardfiles(file::String, ts_folder::String; kwargs...)
+    
+# function parsestandardfiles(file::String, ts_folder::String; kwargs...)
 
-    # TODO: assert a naming convention
-    data = parsestandardfiles(file)
+#     # TODO: assert a naming convention
+#     data = parsestandardfiles(file)
 
-    ts_data = read_data_files(ts_folder; kwargs...)
+#     ts_data = read_data_files(ts_folder; kwargs...)
 
-    # assign_ts_data is in forecast_parser.jl
-    data = assign_ts_data(data,ts_data)
+#     # assign_ts_data is in forecast_parser.jl
+#     data = assign_ts_data(data,ts_data)
 
-    return data
-end
+#     return data
+# end

--- a/src/parsers/standardfiles_parser.jl
+++ b/src/parsers/standardfiles_parser.jl
@@ -7,7 +7,7 @@ function parsestandardfiles(file::String)
     # function `parse_file` is in pm_io/common.jl
     data = parse_file(file)
 
-    #make sure that data is mixed units (in pm_io/data.jl)
+    # make sure that data is mixed units (in pm_io/data.jl)
     make_mixed_units(data)
 
     # Check for at least one bus in input file
@@ -15,6 +15,7 @@ function parsestandardfiles(file::String)
         @error "There are no buses in this file"
     end
 
+    # in pm2ps_parser.jl
     data = pm2ps_dict(data)
 
     return data


### PR DESCRIPTION
A config file was implemented to map string designations of "fuel" and "type" for generators in PowerModels-type source data files to generator classifications in PowerSystems. The config file format is currently TOML because it is easy to read and modify by humans. Note, however, the TOML module that is compatible with Julia 1.x is not registered, and so it needed to be added via url (I tagged the commit that corresponds to release version 0.4.0).

I think this PR can close #131 .

Another note:  I noticed that some generator-device classifications are *not* currently mapped. Even though "Storage" is initialized in ps_dict["gen"], there was (and is) no code to assign anything to Storage. Another I noticed is CSP (concentrated solar power, I presume). These currently default to "Thermal".