### PR TITLE
Enforce ordering of bus and branch numbers in PowerSystem construction.

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -93,7 +93,7 @@ struct PowerSystem{L <: ElectricLoad,
         runchecks = in(:runchecks, keys(kwargs)) ? kwargs[:runchecks] : true
         if runchecks
                 calculatethermallimits!(branches,basepower)
-                checkanglelimits!(branches)
+                check_branches!(branches)
                 #timeserieschecksources(sources.hydro, time_length)
         end
 
@@ -147,7 +147,7 @@ struct PowerSystem{L <: ElectricLoad,
                 buscheck(buses)
                 pvbuscheck(buses, generators)
                 calculatethermallimits!(branches,basepower)
-                checkanglelimits!(branches)
+                check_branches!(branches)
         end
         generators = checkramp(generators, minimumtimestep(loads))
         sources = genclassifier(generators);

--- a/src/utils/IO/base_checks.jl
+++ b/src/utils/IO/base_checks.jl
@@ -41,3 +41,14 @@ function getresolution(ts::TimeSeries.TimeArray)
 
     return res[1]
 end
+
+"""Throws DataFormatError if the array is not in ascending order."""
+function check_ascending_order(array::Array{Int}, name::AbstractString)
+    for (i, num) in enumerate(array)
+        if i > 1 && num < array[i - 1]
+            throw(DataFormatError("$name Numbers are not in ascending order."))
+        end
+    end
+
+    return
+end

--- a/src/utils/IO/branchdata_checks.jl
+++ b/src/utils/IO/branchdata_checks.jl
@@ -1,4 +1,9 @@
 
+function check_branches!(branches::Array{<:Branch,1})
+    checkanglelimits!(branches)
+    check_ascending_order([b.connectionpoints.from.number for b in branches], "Branch")
+end
+
 # function check_angle_limits(anglelimits::(max::Float64, min::Float64))
 function checkanglelimits!(branches::Array{<:Branch,1})
     for (ix,l) in enumerate(branches)

--- a/src/utils/IO/system_checks.jl
+++ b/src/utils/IO/system_checks.jl
@@ -33,6 +33,8 @@ function buscheck(buses::Array{Bus})
             @warn "Bus/Nodes data does not contain information to build an a network"
         end
     end
+
+    check_ascending_order([x.number for x in buses], "Bus")
 end
 
 ## Slack Bus Definition ##

--- a/test/test_base_checks.jl
+++ b/test/test_base_checks.jl
@@ -1,0 +1,11 @@
+
+@testset "Test base checks" begin
+    unordered = [1, 4, 2, 6]
+
+    @test_throws(PowerSystems.DataFormatError,
+                 PowerSystems.check_ascending_order(unordered, "test"))
+
+    ordered = sort(unordered)
+    PowerSystems.check_ascending_order(ordered, "test")
+
+end


### PR DESCRIPTION
This should fix issue #145.