### PR TITLE
Fixed parsing of matpower files that don't end in newline

### DIFF
--- a/src/parsers/im_io/matlab.jl
+++ b/src/parsers/im_io/matlab.jl
@@ -9,13 +9,15 @@
 export parse_matlab_file, parse_matlab_string
 
 function parse_matlab_file(file_string::String; kwargs...)
-    data_string = read(open(file_string),String)
-    return parse_matlab_string(data_string; kwargs...)
+    result = open(file_string) do io
+        lines = readlines(io)
+        return parse_matlab_string(lines; kwargs...)
+    end
+
+    return result
 end
 
-function parse_matlab_string(data_string::String; extended=false)
-    data_lines = split(data_string, '\n')
-
+function parse_matlab_string(data_lines::Array{String}; extended=false)
     matlab_dict = Dict{String,Any}()
     struct_name = nothing
     function_name = nothing
@@ -47,14 +49,14 @@ function parse_matlab_string(data_string::String; extended=false)
                 if haskey(matrix_dict, "column_names") 
                     column_names[matrix_dict["name"]] = matrix_dict["column_names"]
                 end
-                index = index + matrix_dict["line_count"]-1
+                index = index + matrix_dict["line_count"]
             elseif occursin("{", line)
                 cell_dict = parse_matlab_cells(data_lines, index)
                 matlab_dict[cell_dict["name"]] = cell_dict["data"]
                 if haskey(cell_dict, "column_names")
                     column_names[cell_dict["name"]] = cell_dict["column_names"]
                 end
-                index = index + cell_dict["line_count"]-1
+                index = index + cell_dict["line_count"]
             else
                 name, value = extract_matlab_assignment(line)
                 value = type_value(value)

--- a/src/parsers/pm_io/matpower.jl
+++ b/src/parsers/pm_io/matpower.jl
@@ -120,15 +120,15 @@ end
 
 ""
 function parse_matpower_file(io::IO)
-    data_string = read(io, String)
+    lines = readlines(io)
 
-    return parse_matpower_string(data_string)
+    return parse_matpower_string(lines)
 end
 
 
 ""
-function parse_matpower_string(data_string::String)
-    matlab_data, func_name, colnames = parse_matlab_string(data_string, extended=true)
+function parse_matpower_string(data_lines::Array{String})
+    matlab_data, func_name, colnames = parse_matlab_string(data_lines, extended=true)
 
     case = Dict{String,Any}()
 


### PR DESCRIPTION
The function parse_matlab_string created line indices based on how many
"\n" characters were present in the file. There was an off-by-one error
whenever the last character wasn't "\n".  The code would have not worked
at all if a file used line endings of "\r" (pre Mac OS X).