### PR TITLE
 Prototype for simplifying forecast parsing.

### DIFF
--- a/docs/src/man/data.md
+++ b/docs/src/man/data.md
@@ -50,7 +50,7 @@ jq -r '["name", "econ.capacity"], (.components.Device.Injection.Generator.Therma
 jq '.forecasts.data | keys' system.json
 
 ## View the fields of a forecast.
-jq '.forecasts.data["PowerSystems._ForecastKey(2020-01-01T00:00:00, Deterministic{Bus})"][0] | keys'
+jq '.forecasts.data["PowerSystems.ForecastKey(2020-01-01T00:00:00, Deterministic{Bus})"][0] | keys'
 
 ## View the value of every field in an array of forecasts.
-jq '.forecasts.data["PowerSystems._ForecastKey(2020-01-01T00:00:00, Deterministic{Bus})"] | .[].initial_time'
+jq '.forecasts.data["PowerSystems.ForecastKey(2020-01-01T00:00:00, Deterministic{Bus})"] | .[].initial_time'

--- a/src/models/forecasts.jl
+++ b/src/models/forecasts.jl
@@ -40,8 +40,8 @@ end
 """Constructs SystemForecasts from the flat vector of forecasts resulting from parsing."""
 function SystemForecasts(forecasts::Forecasts)
     forecasts_by_type = ForecastsByType()
-    initial_time = Dates.DateTime(Dates.Second(1))
-    resolution = Dates.Period(Dates.Second(1))
+    initial_time = Dates.DateTime(Dates.Second(0))
+    resolution = Dates.Period(Dates.Second(0))
     initialized = false
     horizon::Int64 = 0
 

--- a/src/parsers/standardfiles_parser.jl
+++ b/src/parsers/standardfiles_parser.jl
@@ -29,8 +29,8 @@ function parsestandardfiles(file::String, ts_folder::String; kwargs...)
     
     ts_data = read_data_files(ts_folder; kwargs...)
 
-    forecast = make_forecast_array(sys,ts_data)
-    add_forecast!(sys,:default=>forecast)
+    forecasts = make_forecast_array(sys, ts_data["forecasts"]["forecasts"])
+    add_forecast!(sys, forecasts)
 
     return data
 end

--- a/src/utils/IO/system_checks.jl
+++ b/src/utils/IO/system_checks.jl
@@ -3,12 +3,10 @@
 
 ## Time Series Length ##
 
-function timeseriescheckforecast(forecasts::Dict{Symbol,Array{C,1} where C<:Forecast})
-    for (key,v) in forecasts
-        t = length(unique([length(f.data) for f in v]))
-        if t > 1
-            @error "$key forecast array contains $t different time series lengths"
-        end
+function timeseriescheckforecast(forecasts::Forecasts)
+    t = length(unique([length(f) for f in forecasts]))
+    if t > 1
+        @error "forecast array contains $t different time series lengths"
     end
 end
 


### PR DESCRIPTION
This is a starting point for discussion on issue #249.  I changed the forecast parsing code to build a flat array of forecast dictionaries instead of a deeply nested dictionary keyed by the forecast attributes.

They array of forecasts gets passed to the System constructor.  The System breaks up the forecasts into its own optimized data structure.

I have several open questions about some specifics (resolution, initial_time, etc.), but am hoping that this is a more extensible design.  Let me know what you think.

I did not update the tests because it would require a bit of refactoring.  I want to get agreement first.  To test the code I performed these steps:
```
cdm_dict = PowerSystems.csv2ps_dict("./data/RTS_GMLC", 100.0);
sys = System(cdm_dict)
for forecast in iterate_forecasts(sys)
    @show forecast
end
```

Current status as of 1pm on 5/24:
- Changed the target of this PR to PowerSystems/forecast-parsing instead of dev.  @jd-lara may implement some additions.  If he does, he will need to perform a merge of this PR.
- Need to have discussion with Clayton about these interfaces before proceeding much further.
- Need to discussion with Clayton and Dheepak about longer-term interfaces for parsing.  The intermediate dictionary we produce currently (ps_dict) is not ideal.  Jose and I discussed some possibilities today.  Parsing could produce either existing PowerSystems structs or simplified, mutable versions that can be fed into the System constructor.  The forecast parsing points out why this could be desirable.  With the current plan the user will need to filter out forecasts to ensure only one resolution exists.  Doing this with structs would be much clearer than with dictionaries.