### PR TITLE
Type fixes

### DIFF
--- a/src/models/topological_elements.jl
+++ b/src/models/topological_elements.jl
@@ -1,5 +1,5 @@
 
-abstract type Topological <: Device end
+abstract type Topological <: Component end
 """
     Bus
 

--- a/src/models/topological_elements.jl
+++ b/src/models/topological_elements.jl
@@ -1,3 +1,5 @@
+
+abstract type Topological <: Device end
 """
     Bus
 
@@ -18,7 +20,7 @@ Bus(number, name, bustype, angle, voltage, voltagelimits, basevoltage)
 * `basevoltage`::Float64 : the base voltage in kV; may be `nothing`
 
 """
-struct Bus <: Injection
+struct Bus <: Topological
     # field docstrings work here! (they are not for System)
     """ number associated with the bus """
     number::Int64
@@ -57,7 +59,7 @@ Bus(;   number = 0,
             orderedlimits(voltagelimits, "Voltage"), basevoltage)
 
 # DOCTODO What are LoadZones? JJS 1/18/19
-struct LoadZones  <: Injection
+struct LoadZones  <: Topological
     number::Int
     name::String
     buses::Array{Bus,1}


### PR DESCRIPTION
Add new category for topological components and separate it from `injection`. Creates an explicit separation such that a `device` represents physical components of the system. 

This PR leads to thinking we need to rename `component` to a more generic type like element (?) or another name. Also because during the dynamic model components should be used to define parts inside of the device e.g. AVR is a component of a generator.

The tree will look like this

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/16385323/59003150-aa7ce980-87c9-11e9-9e28-5ea665c67fe3.png">
