### PR TITLE
update structs

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,4 +1,3 @@
-
 const Min_Max = NamedTuple{(:min, :max),Tuple{Float64,Float64}}
 const From_To_Float = NamedTuple{(:from, :to),Tuple{Float64,Float64}}
 const FromTo_ToFrom_Float = NamedTuple{(:from_to, :to_from),Tuple{Float64,Float64}}

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -61,24 +61,20 @@
         "data_type": "Float64"
       },
       {
-        "name": "activepower",
-        "null_value": "0.0",
-        "data_type": "Float64"
+        "name": "primemover",
+        "comment": "PrimeMover Technology according to EIA 923",
+        "null_value": "nothing",
+        "data_type": "Union{Nothing,PrimeMovers}"
       },
       {
         "name": "activepowerlimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
-      },
-      {
-        "name": "reactivepower",
-        "null_value": "0.0",
-        "data_type": "Float64"
+        "data_type": "Min_Max"
       },
       {
         "name": "reactivepowerlimits",
         "null_value": "nothing",
-        "data_type": "Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}"
+        "data_type": "Union{Nothing, Min_Max}"
       },
       {
         "name": "ramplimits",
@@ -107,14 +103,15 @@
         "data_type": "Float64"
       },
       {
-        "name": "reactivepower",
-        "null_value": "0.0",
-        "data_type": "Float64"
+        "name": "primemover",
+        "comment": "PrimeMover Technology according to EIA 923",
+        "null_value": "nothing",
+        "data_type": "Union{Nothing,PrimeMovers}"
       },
       {
         "name": "reactivepowerlimits",
         "null_value": "nothing",
-        "data_type": "Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}"
+        "data_type": "Union{Nothing, Min_Max}"
       },
       {
         "name": "powerfactor",
@@ -139,24 +136,26 @@
         "data_type": "Float64"
       },
       {
-        "name": "activepower",
-        "null_value": "0.0",
-        "data_type": "Float64"
+        "name": "primemover",
+        "comment": "PrimeMover Technology according to EIA 923",
+        "null_value": "nothing",
+        "data_type": "Union{Nothing,PrimeMovers}"
+      },
+      {
+        "name": "fuel",
+        "comment": "PrimeMover Technology according to EIA 923",
+        "null_value": "nothing",
+        "data_type": "Union{Nothing,ThermalFuels}"
       },
       {
         "name": "activepowerlimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
-      },
-      {
-        "name": "reactivepower",
-        "null_value": "0.0",
-        "data_type": "Float64"
+        "data_type": "Min_Max"
       },
       {
         "name": "reactivepowerlimits",
         "null_value": "nothing",
-        "data_type": "Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}"
+        "data_type": "Union{Nothing, Min_Max}"
       },
       {
         "name": "ramplimits",
@@ -214,7 +213,7 @@
         "name": "voltagelimits",
         "comment": "limits on the voltage variation as multiples of basevoltage",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}"
+        "data_type": "Union{Nothing, Min_Max}"
       },
       {
         "name": "basevoltage",
@@ -264,6 +263,16 @@
         "data_type": "Bool"
       },
       {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
         "name": "arch",
         "data_type": "Arch"
@@ -291,7 +300,7 @@
       {
         "name": "anglelimits",
         "null_value": "(min=-90.0, max=-90.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "internal",
@@ -312,6 +321,16 @@
         "null_value": "false",
         "name": "available",
         "data_type": "Bool"
+      },
+      {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
@@ -346,7 +365,7 @@
       {
         "name": "anglelimits",
         "null_value": "(min=-90.0, max=-90.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "internal",
@@ -367,6 +386,16 @@
         "null_value": "false",
         "name": "available",
         "data_type": "Bool"
+      },
+      {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
@@ -424,6 +453,16 @@
         "data_type": "Bool"
       },
       {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
         "name": "arch",
         "data_type": "Arch"
@@ -473,6 +512,16 @@
         "null_value": "false",
         "name": "available",
         "data_type": "Bool"
+      },
+      {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
@@ -525,24 +574,29 @@
         "data_type": "Arch"
       },
       {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "name": "activepowerlimits_from",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "activepowerlimits_to",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "reactivepowerlimits_from",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "reactivepowerlimits_to",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "loss",
@@ -571,6 +625,11 @@
         "data_type": "Bool"
       },
       {
+        "name": "activepower_flow",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "null_value": "Arch(Bus(nothing), Bus(nothing))",
         "name": "arch",
         "data_type": "Arch"
@@ -578,7 +637,7 @@
       {
         "name": "rectifier_taplimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "rectifier_xrc",
@@ -586,14 +645,14 @@
         "data_type": "Float64"
       },
       {
-        "name": "rectifier_firingangle",
+        "name": "rectifier_firing_angle",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "inverter_taplimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "inverter_xrc",
@@ -601,9 +660,9 @@
         "data_type": "Float64"
       },
       {
-        "name": "inverter_firingangle",
+        "name": "inverter_firing_angle",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "internal",
@@ -624,6 +683,16 @@
         "null_value": "false",
         "name": "available",
         "data_type": "Bool"
+      },
+      {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "name": "bus",
@@ -707,6 +776,16 @@
         "data_type": "Bus"
       },
       {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "name": "maxactivepower",
         "null_value": "0.0",
         "data_type": "Float64"
@@ -740,6 +819,16 @@
         "name": "bus",
         "null_value": "Bus(nothing)",
         "data_type": "Bus"
+      },
+      {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "name": "tech",
@@ -777,6 +866,16 @@
         "data_type": "Bus"
       },
       {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "name": "tech",
         "null_value": "TechHydro(nothing)",
         "data_type": "TechHydro"
@@ -805,6 +904,16 @@
         "name": "bus",
         "null_value": "Bus(nothing)",
         "data_type": "Bus"
+      },
+      {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "name": "tech",
@@ -852,6 +961,16 @@
         "data_type": "Bus"
       },
       {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "name": "tech",
         "null_value": "TechRenewable(nothing)",
         "data_type": "TechRenewable"
@@ -887,6 +1006,16 @@
         "data_type": "Bus"
       },
       {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
         "name": "tech",
         "null_value": "TechRenewable(nothing)",
         "data_type": "TechRenewable"
@@ -916,6 +1045,16 @@
         "name": "bus",
         "null_value": "Bus(nothing)",
         "data_type": "Bus"
+      },
+      {
+        "name": "activepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
+      },
+      {
+        "name": "reactivepower",
+        "null_value": "0.0",
+        "data_type": "Float64"
       },
       {
         "name": "tech",
@@ -979,6 +1118,12 @@
         "data_type": "String"
       },
       {
+        "name": "primemover",
+        "comment": "PrimeMover Technology according to EIA 923",
+        "null_value": "nothing",
+        "data_type": "Union{Nothing,PrimeMovers}"
+      },
+      {
         "null_value": "false",
         "name": "available",
         "data_type": "Bool"
@@ -998,7 +1143,7 @@
         "name": "capacity",
         "null_value": "(min=0.0, max=0.0)",
         "comment": "Maximum and Minimum storage capacity in p.u.-hr",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "rating",
@@ -1013,12 +1158,12 @@
       {
         "name": "inputactivepowerlimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "outputactivepowerlimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "NamedTuple{(:min, :max), Tuple{Float64, Float64}}"
+        "data_type": "Min_Max"
       },
       {
         "name": "efficiency",
@@ -1033,7 +1178,7 @@
       {
         "name": "reactivepowerlimits",
         "null_value": "(min=0.0, max=0.0)",
-        "data_type": "Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}"
+        "data_type": "Union{Nothing, Min_Max}"
       },
       {
         "name": "internal",

--- a/src/models/generated/Bus.jl
+++ b/src/models/generated/Bus.jl
@@ -9,7 +9,7 @@ mutable struct Bus <: Topology
     bustype::Union{Nothing, BusType}  # bus type
     angle::Union{Nothing, Float64}  # angle of the bus in radians
     voltage::Union{Nothing, Float64}  # voltage as a multiple of basevoltage
-    voltagelimits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}  # limits on the voltage variation as multiples of basevoltage
+    voltagelimits::Union{Nothing, Min_Max}  # limits on the voltage variation as multiples of basevoltage
     basevoltage::Union{Nothing, Float64}  # the base voltage in kV
     internal::PowerSystems.PowerSystemInternal
 

--- a/src/models/generated/GenericBattery.jl
+++ b/src/models/generated/GenericBattery.jl
@@ -5,26 +5,27 @@ This file is auto-generated. Do not edit.
 
 mutable struct GenericBattery <: Storage
     name::String
+    primemover::Union{Nothing,PrimeMovers}  # PrimeMover Technology according to EIA 923
     available::Bool
     bus::Bus
     energy::Float64  # State of Charge of the Battery p.u.-hr
-    capacity::NamedTuple{(:min, :max), Tuple{Float64, Float64}}  # Maximum and Minimum storage capacity in p.u.-hr
+    capacity::Min_Max  # Maximum and Minimum storage capacity in p.u.-hr
     rating::Float64
     activepower::Float64
-    inputactivepowerlimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    outputactivepowerlimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    inputactivepowerlimits::Min_Max
+    outputactivepowerlimits::Min_Max
     efficiency::NamedTuple{(:in, :out), Tuple{Float64, Float64}}
     reactivepower::Float64
-    reactivepowerlimits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
+    reactivepowerlimits::Union{Nothing, Min_Max}
     internal::PowerSystems.PowerSystemInternal
 end
 
-function GenericBattery(name, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
-    GenericBattery(name, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, PowerSystemInternal())
+function GenericBattery(name, primemover, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
+    GenericBattery(name, primemover, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, PowerSystemInternal())
 end
 
-function GenericBattery(; name, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
-    GenericBattery(name, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
+function GenericBattery(; name, primemover, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
+    GenericBattery(name, primemover, available, bus, energy, capacity, rating, activepower, inputactivepowerlimits, outputactivepowerlimits, efficiency, reactivepower, reactivepowerlimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -32,6 +33,7 @@ end
 function GenericBattery(::Nothing)
     GenericBattery(;
         name="init",
+        primemover=nothing,
         available=false,
         bus=Bus(nothing),
         energy=0.0,
@@ -48,6 +50,8 @@ end
 
 """Get GenericBattery name."""
 get_name(value::GenericBattery) = value.name
+"""Get GenericBattery primemover."""
+get_primemover(value::GenericBattery) = value.primemover
 """Get GenericBattery available."""
 get_available(value::GenericBattery) = value.available
 """Get GenericBattery bus."""

--- a/src/models/generated/HVDCLine.jl
+++ b/src/models/generated/HVDCLine.jl
@@ -7,20 +7,21 @@ mutable struct HVDCLine <: DCBranch
     name::String
     available::Bool
     arch::Arch
-    activepowerlimits_from::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    activepowerlimits_to::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    reactivepowerlimits_from::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    reactivepowerlimits_to::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    activepower_flow::Float64
+    activepowerlimits_from::Min_Max
+    activepowerlimits_to::Min_Max
+    reactivepowerlimits_from::Min_Max
+    reactivepowerlimits_to::Min_Max
     loss::NamedTuple{(:l0, :l1), Tuple{Float64, Float64}}
     internal::PowerSystems.PowerSystemInternal
 end
 
-function HVDCLine(name, available, arch, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
-    HVDCLine(name, available, arch, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, PowerSystemInternal())
+function HVDCLine(name, available, arch, activepower_flow, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
+    HVDCLine(name, available, arch, activepower_flow, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, PowerSystemInternal())
 end
 
-function HVDCLine(; name, available, arch, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
-    HVDCLine(name, available, arch, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
+function HVDCLine(; name, available, arch, activepower_flow, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
+    HVDCLine(name, available, arch, activepower_flow, activepowerlimits_from, activepowerlimits_to, reactivepowerlimits_from, reactivepowerlimits_to, loss, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -30,6 +31,7 @@ function HVDCLine(::Nothing)
         name="init",
         available=false,
         arch=Arch(Bus(nothing), Bus(nothing)),
+        activepower_flow=0.0,
         activepowerlimits_from=(min=0.0, max=0.0),
         activepowerlimits_to=(min=0.0, max=0.0),
         reactivepowerlimits_from=(min=0.0, max=0.0),
@@ -44,6 +46,8 @@ get_name(value::HVDCLine) = value.name
 get_available(value::HVDCLine) = value.available
 """Get HVDCLine arch."""
 get_arch(value::HVDCLine) = value.arch
+"""Get HVDCLine activepower_flow."""
+get_activepower_flow(value::HVDCLine) = value.activepower_flow
 """Get HVDCLine activepowerlimits_from."""
 get_activepowerlimits_from(value::HVDCLine) = value.activepowerlimits_from
 """Get HVDCLine activepowerlimits_to."""

--- a/src/models/generated/HydroDispatch.jl
+++ b/src/models/generated/HydroDispatch.jl
@@ -7,17 +7,19 @@ mutable struct HydroDispatch <: HydroGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::TechHydro
     op_cost::TwoPartCost
     internal::PowerSystems.PowerSystemInternal
 end
 
-function HydroDispatch(name, available, bus, tech, op_cost, )
-    HydroDispatch(name, available, bus, tech, op_cost, PowerSystemInternal())
+function HydroDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, )
+    HydroDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, PowerSystemInternal())
 end
 
-function HydroDispatch(; name, available, bus, tech, op_cost, )
-    HydroDispatch(name, available, bus, tech, op_cost, )
+function HydroDispatch(; name, available, bus, activepower, reactivepower, tech, op_cost, )
+    HydroDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,6 +29,8 @@ function HydroDispatch(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechHydro(nothing),
         op_cost=TwoPartCost(nothing),
     )
@@ -38,6 +42,10 @@ get_name(value::HydroDispatch) = value.name
 get_available(value::HydroDispatch) = value.available
 """Get HydroDispatch bus."""
 get_bus(value::HydroDispatch) = value.bus
+"""Get HydroDispatch activepower."""
+get_activepower(value::HydroDispatch) = value.activepower
+"""Get HydroDispatch reactivepower."""
+get_reactivepower(value::HydroDispatch) = value.reactivepower
 """Get HydroDispatch tech."""
 get_tech(value::HydroDispatch) = value.tech
 """Get HydroDispatch op_cost."""

--- a/src/models/generated/HydroFix.jl
+++ b/src/models/generated/HydroFix.jl
@@ -7,16 +7,18 @@ mutable struct HydroFix <: HydroGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::TechHydro
     internal::PowerSystems.PowerSystemInternal
 end
 
-function HydroFix(name, available, bus, tech, )
-    HydroFix(name, available, bus, tech, PowerSystemInternal())
+function HydroFix(name, available, bus, activepower, reactivepower, tech, )
+    HydroFix(name, available, bus, activepower, reactivepower, tech, PowerSystemInternal())
 end
 
-function HydroFix(; name, available, bus, tech, )
-    HydroFix(name, available, bus, tech, )
+function HydroFix(; name, available, bus, activepower, reactivepower, tech, )
+    HydroFix(name, available, bus, activepower, reactivepower, tech, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -26,6 +28,8 @@ function HydroFix(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechHydro(nothing),
     )
 end
@@ -36,6 +40,10 @@ get_name(value::HydroFix) = value.name
 get_available(value::HydroFix) = value.available
 """Get HydroFix bus."""
 get_bus(value::HydroFix) = value.bus
+"""Get HydroFix activepower."""
+get_activepower(value::HydroFix) = value.activepower
+"""Get HydroFix reactivepower."""
+get_reactivepower(value::HydroFix) = value.reactivepower
 """Get HydroFix tech."""
 get_tech(value::HydroFix) = value.tech
 """Get HydroFix internal."""

--- a/src/models/generated/HydroStorage.jl
+++ b/src/models/generated/HydroStorage.jl
@@ -7,6 +7,8 @@ mutable struct HydroStorage <: HydroGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::TechHydro
     op_cost::TwoPartCost
     storagecapacity::Float64
@@ -14,12 +16,12 @@ mutable struct HydroStorage <: HydroGen
     internal::PowerSystems.PowerSystemInternal
 end
 
-function HydroStorage(name, available, bus, tech, op_cost, storagecapacity, initial_storage, )
-    HydroStorage(name, available, bus, tech, op_cost, storagecapacity, initial_storage, PowerSystemInternal())
+function HydroStorage(name, available, bus, activepower, reactivepower, tech, op_cost, storagecapacity, initial_storage, )
+    HydroStorage(name, available, bus, activepower, reactivepower, tech, op_cost, storagecapacity, initial_storage, PowerSystemInternal())
 end
 
-function HydroStorage(; name, available, bus, tech, op_cost, storagecapacity, initial_storage, )
-    HydroStorage(name, available, bus, tech, op_cost, storagecapacity, initial_storage, )
+function HydroStorage(; name, available, bus, activepower, reactivepower, tech, op_cost, storagecapacity, initial_storage, )
+    HydroStorage(name, available, bus, activepower, reactivepower, tech, op_cost, storagecapacity, initial_storage, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -29,6 +31,8 @@ function HydroStorage(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechHydro(nothing),
         op_cost=TwoPartCost(nothing),
         storagecapacity=0.0,
@@ -42,6 +46,10 @@ get_name(value::HydroStorage) = value.name
 get_available(value::HydroStorage) = value.available
 """Get HydroStorage bus."""
 get_bus(value::HydroStorage) = value.bus
+"""Get HydroStorage activepower."""
+get_activepower(value::HydroStorage) = value.activepower
+"""Get HydroStorage reactivepower."""
+get_reactivepower(value::HydroStorage) = value.reactivepower
 """Get HydroStorage tech."""
 get_tech(value::HydroStorage) = value.tech
 """Get HydroStorage op_cost."""

--- a/src/models/generated/InterruptibleLoad.jl
+++ b/src/models/generated/InterruptibleLoad.jl
@@ -6,6 +6,8 @@ This file is auto-generated. Do not edit.
 mutable struct InterruptibleLoad <: ControllableLoad
     name::String
     available::Bool
+    activepower::Float64
+    reactivepower::Float64
     bus::Bus
     model::String  # [Z, I, P]
     maxactivepower::Float64
@@ -14,12 +16,12 @@ mutable struct InterruptibleLoad <: ControllableLoad
     internal::PowerSystems.PowerSystemInternal
 end
 
-function InterruptibleLoad(name, available, bus, model, maxactivepower, maxreactivepower, op_cost, )
-    InterruptibleLoad(name, available, bus, model, maxactivepower, maxreactivepower, op_cost, PowerSystemInternal())
+function InterruptibleLoad(name, available, activepower, reactivepower, bus, model, maxactivepower, maxreactivepower, op_cost, )
+    InterruptibleLoad(name, available, activepower, reactivepower, bus, model, maxactivepower, maxreactivepower, op_cost, PowerSystemInternal())
 end
 
-function InterruptibleLoad(; name, available, bus, model, maxactivepower, maxreactivepower, op_cost, )
-    InterruptibleLoad(name, available, bus, model, maxactivepower, maxreactivepower, op_cost, )
+function InterruptibleLoad(; name, available, activepower, reactivepower, bus, model, maxactivepower, maxreactivepower, op_cost, )
+    InterruptibleLoad(name, available, activepower, reactivepower, bus, model, maxactivepower, maxreactivepower, op_cost, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -28,6 +30,8 @@ function InterruptibleLoad(::Nothing)
     InterruptibleLoad(;
         name="init",
         available=false,
+        activepower=0.0,
+        reactivepower=0.0,
         bus=Bus(nothing),
         model="0",
         maxactivepower=0,
@@ -40,6 +44,10 @@ end
 get_name(value::InterruptibleLoad) = value.name
 """Get InterruptibleLoad available."""
 get_available(value::InterruptibleLoad) = value.available
+"""Get InterruptibleLoad activepower."""
+get_activepower(value::InterruptibleLoad) = value.activepower
+"""Get InterruptibleLoad reactivepower."""
+get_reactivepower(value::InterruptibleLoad) = value.reactivepower
 """Get InterruptibleLoad bus."""
 get_bus(value::InterruptibleLoad) = value.bus
 """Get InterruptibleLoad model."""

--- a/src/models/generated/Line.jl
+++ b/src/models/generated/Line.jl
@@ -6,21 +6,23 @@ This file is auto-generated. Do not edit.
 mutable struct Line <: ACBranch
     name::String
     available::Bool
+    activepower_flow::Float64
+    reactivepower_flow::Float64
     arch::Arch
     r::Float64
     x::Float64
     b::NamedTuple{(:from, :to), Tuple{Float64, Float64}}
     rate::Float64
-    anglelimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    anglelimits::Min_Max
     internal::PowerSystems.PowerSystemInternal
 end
 
-function Line(name, available, arch, r, x, b, rate, anglelimits, )
-    Line(name, available, arch, r, x, b, rate, anglelimits, PowerSystemInternal())
+function Line(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, rate, anglelimits, )
+    Line(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, rate, anglelimits, PowerSystemInternal())
 end
 
-function Line(; name, available, arch, r, x, b, rate, anglelimits, )
-    Line(name, available, arch, r, x, b, rate, anglelimits, )
+function Line(; name, available, activepower_flow, reactivepower_flow, arch, r, x, b, rate, anglelimits, )
+    Line(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, rate, anglelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -29,6 +31,8 @@ function Line(::Nothing)
     Line(;
         name="init",
         available=false,
+        activepower_flow=0.0,
+        reactivepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         r=0.0,
         x=0.0,
@@ -42,6 +46,10 @@ end
 get_name(value::Line) = value.name
 """Get Line available."""
 get_available(value::Line) = value.available
+"""Get Line activepower_flow."""
+get_activepower_flow(value::Line) = value.activepower_flow
+"""Get Line reactivepower_flow."""
+get_reactivepower_flow(value::Line) = value.reactivepower_flow
 """Get Line arch."""
 get_arch(value::Line) = value.arch
 """Get Line r."""

--- a/src/models/generated/MonitoredLine.jl
+++ b/src/models/generated/MonitoredLine.jl
@@ -6,22 +6,24 @@ This file is auto-generated. Do not edit.
 mutable struct MonitoredLine <: ACBranch
     name::String
     available::Bool
+    activepower_flow::Float64
+    reactivepower_flow::Float64
     arch::Arch
     r::Float64
     x::Float64
     b::NamedTuple{(:from, :to), Tuple{Float64, Float64}}
     flowlimits::NamedTuple{(:from_to, :to_from), Tuple{Float64, Float64}}
     rate::Float64
-    anglelimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    anglelimits::Min_Max
     internal::PowerSystems.PowerSystemInternal
 end
 
-function MonitoredLine(name, available, arch, r, x, b, flowlimits, rate, anglelimits, )
-    MonitoredLine(name, available, arch, r, x, b, flowlimits, rate, anglelimits, PowerSystemInternal())
+function MonitoredLine(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, flowlimits, rate, anglelimits, )
+    MonitoredLine(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, flowlimits, rate, anglelimits, PowerSystemInternal())
 end
 
-function MonitoredLine(; name, available, arch, r, x, b, flowlimits, rate, anglelimits, )
-    MonitoredLine(name, available, arch, r, x, b, flowlimits, rate, anglelimits, )
+function MonitoredLine(; name, available, activepower_flow, reactivepower_flow, arch, r, x, b, flowlimits, rate, anglelimits, )
+    MonitoredLine(name, available, activepower_flow, reactivepower_flow, arch, r, x, b, flowlimits, rate, anglelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -30,6 +32,8 @@ function MonitoredLine(::Nothing)
     MonitoredLine(;
         name="init",
         available=false,
+        activepower_flow=0.0,
+        reactivepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         r=0.0,
         x=0.0,
@@ -44,6 +48,10 @@ end
 get_name(value::MonitoredLine) = value.name
 """Get MonitoredLine available."""
 get_available(value::MonitoredLine) = value.available
+"""Get MonitoredLine activepower_flow."""
+get_activepower_flow(value::MonitoredLine) = value.activepower_flow
+"""Get MonitoredLine reactivepower_flow."""
+get_reactivepower_flow(value::MonitoredLine) = value.reactivepower_flow
 """Get MonitoredLine arch."""
 get_arch(value::MonitoredLine) = value.arch
 """Get MonitoredLine r."""

--- a/src/models/generated/PhaseShiftingTransformer.jl
+++ b/src/models/generated/PhaseShiftingTransformer.jl
@@ -6,6 +6,8 @@ This file is auto-generated. Do not edit.
 mutable struct PhaseShiftingTransformer <: ACBranch
     name::String
     available::Bool
+    activepower_flow::Float64
+    reactivepower_flow::Float64
     arch::Arch
     r::Float64
     x::Float64
@@ -16,12 +18,12 @@ mutable struct PhaseShiftingTransformer <: ACBranch
     internal::PowerSystems.PowerSystemInternal
 end
 
-function PhaseShiftingTransformer(name, available, arch, r, x, primaryshunt, tap, α, rate, )
-    PhaseShiftingTransformer(name, available, arch, r, x, primaryshunt, tap, α, rate, PowerSystemInternal())
+function PhaseShiftingTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, α, rate, )
+    PhaseShiftingTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, α, rate, PowerSystemInternal())
 end
 
-function PhaseShiftingTransformer(; name, available, arch, r, x, primaryshunt, tap, α, rate, )
-    PhaseShiftingTransformer(name, available, arch, r, x, primaryshunt, tap, α, rate, )
+function PhaseShiftingTransformer(; name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, α, rate, )
+    PhaseShiftingTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, α, rate, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -30,6 +32,8 @@ function PhaseShiftingTransformer(::Nothing)
     PhaseShiftingTransformer(;
         name="init",
         available=false,
+        activepower_flow=0.0,
+        reactivepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         r=0.0,
         x=0.0,
@@ -44,6 +48,10 @@ end
 get_name(value::PhaseShiftingTransformer) = value.name
 """Get PhaseShiftingTransformer available."""
 get_available(value::PhaseShiftingTransformer) = value.available
+"""Get PhaseShiftingTransformer activepower_flow."""
+get_activepower_flow(value::PhaseShiftingTransformer) = value.activepower_flow
+"""Get PhaseShiftingTransformer reactivepower_flow."""
+get_reactivepower_flow(value::PhaseShiftingTransformer) = value.reactivepower_flow
 """Get PhaseShiftingTransformer arch."""
 get_arch(value::PhaseShiftingTransformer) = value.arch
 """Get PhaseShiftingTransformer r."""

--- a/src/models/generated/PowerLoad.jl
+++ b/src/models/generated/PowerLoad.jl
@@ -7,17 +7,19 @@ mutable struct PowerLoad <: StaticLoad
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     maxactivepower::Float64
     maxreactivepower::Float64
     internal::PowerSystems.PowerSystemInternal
 end
 
-function PowerLoad(name, available, bus, maxactivepower, maxreactivepower, )
-    PowerLoad(name, available, bus, maxactivepower, maxreactivepower, PowerSystemInternal())
+function PowerLoad(name, available, bus, activepower, reactivepower, maxactivepower, maxreactivepower, )
+    PowerLoad(name, available, bus, activepower, reactivepower, maxactivepower, maxreactivepower, PowerSystemInternal())
 end
 
-function PowerLoad(; name, available, bus, maxactivepower, maxreactivepower, )
-    PowerLoad(name, available, bus, maxactivepower, maxreactivepower, )
+function PowerLoad(; name, available, bus, activepower, reactivepower, maxactivepower, maxreactivepower, )
+    PowerLoad(name, available, bus, activepower, reactivepower, maxactivepower, maxreactivepower, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,6 +29,8 @@ function PowerLoad(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         maxactivepower=0.0,
         maxreactivepower=0.0,
     )
@@ -38,6 +42,10 @@ get_name(value::PowerLoad) = value.name
 get_available(value::PowerLoad) = value.available
 """Get PowerLoad bus."""
 get_bus(value::PowerLoad) = value.bus
+"""Get PowerLoad activepower."""
+get_activepower(value::PowerLoad) = value.activepower
+"""Get PowerLoad reactivepower."""
+get_reactivepower(value::PowerLoad) = value.reactivepower
 """Get PowerLoad maxactivepower."""
 get_maxactivepower(value::PowerLoad) = value.maxactivepower
 """Get PowerLoad maxreactivepower."""

--- a/src/models/generated/RenewableDispatch.jl
+++ b/src/models/generated/RenewableDispatch.jl
@@ -7,17 +7,19 @@ mutable struct RenewableDispatch <: RenewableGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::TechRenewable
     op_cost::TwoPartCost
     internal::PowerSystems.PowerSystemInternal
 end
 
-function RenewableDispatch(name, available, bus, tech, op_cost, )
-    RenewableDispatch(name, available, bus, tech, op_cost, PowerSystemInternal())
+function RenewableDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, )
+    RenewableDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, PowerSystemInternal())
 end
 
-function RenewableDispatch(; name, available, bus, tech, op_cost, )
-    RenewableDispatch(name, available, bus, tech, op_cost, )
+function RenewableDispatch(; name, available, bus, activepower, reactivepower, tech, op_cost, )
+    RenewableDispatch(name, available, bus, activepower, reactivepower, tech, op_cost, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,6 +29,8 @@ function RenewableDispatch(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechRenewable(nothing),
         op_cost=TwoPartCost(nothing),
     )
@@ -38,6 +42,10 @@ get_name(value::RenewableDispatch) = value.name
 get_available(value::RenewableDispatch) = value.available
 """Get RenewableDispatch bus."""
 get_bus(value::RenewableDispatch) = value.bus
+"""Get RenewableDispatch activepower."""
+get_activepower(value::RenewableDispatch) = value.activepower
+"""Get RenewableDispatch reactivepower."""
+get_reactivepower(value::RenewableDispatch) = value.reactivepower
 """Get RenewableDispatch tech."""
 get_tech(value::RenewableDispatch) = value.tech
 """Get RenewableDispatch op_cost."""

--- a/src/models/generated/RenewableFix.jl
+++ b/src/models/generated/RenewableFix.jl
@@ -7,16 +7,18 @@ mutable struct RenewableFix <: RenewableGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::TechRenewable
     internal::PowerSystems.PowerSystemInternal
 end
 
-function RenewableFix(name, available, bus, tech, )
-    RenewableFix(name, available, bus, tech, PowerSystemInternal())
+function RenewableFix(name, available, bus, activepower, reactivepower, tech, )
+    RenewableFix(name, available, bus, activepower, reactivepower, tech, PowerSystemInternal())
 end
 
-function RenewableFix(; name, available, bus, tech, )
-    RenewableFix(name, available, bus, tech, )
+function RenewableFix(; name, available, bus, activepower, reactivepower, tech, )
+    RenewableFix(name, available, bus, activepower, reactivepower, tech, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -26,6 +28,8 @@ function RenewableFix(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechRenewable(nothing),
     )
 end
@@ -36,6 +40,10 @@ get_name(value::RenewableFix) = value.name
 get_available(value::RenewableFix) = value.available
 """Get RenewableFix bus."""
 get_bus(value::RenewableFix) = value.bus
+"""Get RenewableFix activepower."""
+get_activepower(value::RenewableFix) = value.activepower
+"""Get RenewableFix reactivepower."""
+get_reactivepower(value::RenewableFix) = value.reactivepower
 """Get RenewableFix tech."""
 get_tech(value::RenewableFix) = value.tech
 """Get RenewableFix internal."""

--- a/src/models/generated/TapTransformer.jl
+++ b/src/models/generated/TapTransformer.jl
@@ -6,6 +6,8 @@ This file is auto-generated. Do not edit.
 mutable struct TapTransformer <: ACBranch
     name::String
     available::Bool
+    activepower_flow::Float64
+    reactivepower_flow::Float64
     arch::Arch
     r::Float64
     x::Float64
@@ -15,12 +17,12 @@ mutable struct TapTransformer <: ACBranch
     internal::PowerSystems.PowerSystemInternal
 end
 
-function TapTransformer(name, available, arch, r, x, primaryshunt, tap, rate, )
-    TapTransformer(name, available, arch, r, x, primaryshunt, tap, rate, PowerSystemInternal())
+function TapTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, rate, )
+    TapTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, rate, PowerSystemInternal())
 end
 
-function TapTransformer(; name, available, arch, r, x, primaryshunt, tap, rate, )
-    TapTransformer(name, available, arch, r, x, primaryshunt, tap, rate, )
+function TapTransformer(; name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, rate, )
+    TapTransformer(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, tap, rate, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -29,6 +31,8 @@ function TapTransformer(::Nothing)
     TapTransformer(;
         name="init",
         available=false,
+        activepower_flow=0.0,
+        reactivepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         r=0.0,
         x=0.0,
@@ -42,6 +46,10 @@ end
 get_name(value::TapTransformer) = value.name
 """Get TapTransformer available."""
 get_available(value::TapTransformer) = value.available
+"""Get TapTransformer activepower_flow."""
+get_activepower_flow(value::TapTransformer) = value.activepower_flow
+"""Get TapTransformer reactivepower_flow."""
+get_reactivepower_flow(value::TapTransformer) = value.reactivepower_flow
 """Get TapTransformer arch."""
 get_arch(value::TapTransformer) = value.arch
 """Get TapTransformer r."""

--- a/src/models/generated/TechHydro.jl
+++ b/src/models/generated/TechHydro.jl
@@ -5,21 +5,20 @@ This file is auto-generated. Do not edit.
 
 mutable struct TechHydro <: PowerSystems.TechnicalParams
     rating::Float64  # Thermal limited MVA Power Output of the unit. &lt;= Capacity 
-    activepower::Float64
-    activepowerlimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    reactivepower::Float64
-    reactivepowerlimits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
+    primemover::Union{Nothing,PrimeMovers}  # PrimeMover Technology according to EIA 923
+    activepowerlimits::Min_Max
+    reactivepowerlimits::Union{Nothing, Min_Max}
     ramplimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     timelimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     internal::PowerSystems.PowerSystemInternal
 end
 
-function TechHydro(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
-    TechHydro(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, PowerSystemInternal())
+function TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, PowerSystemInternal())
 end
 
-function TechHydro(; rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
-    TechHydro(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
+function TechHydro(; rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,9 +26,8 @@ end
 function TechHydro(::Nothing)
     TechHydro(;
         rating=0.0,
-        activepower=0.0,
+        primemover=nothing,
         activepowerlimits=(min=0.0, max=0.0),
-        reactivepower=0.0,
         reactivepowerlimits=nothing,
         ramplimits=nothing,
         timelimits=nothing,
@@ -38,12 +36,10 @@ end
 
 """Get TechHydro rating."""
 get_rating(value::TechHydro) = value.rating
-"""Get TechHydro activepower."""
-get_activepower(value::TechHydro) = value.activepower
+"""Get TechHydro primemover."""
+get_primemover(value::TechHydro) = value.primemover
 """Get TechHydro activepowerlimits."""
 get_activepowerlimits(value::TechHydro) = value.activepowerlimits
-"""Get TechHydro reactivepower."""
-get_reactivepower(value::TechHydro) = value.reactivepower
 """Get TechHydro reactivepowerlimits."""
 get_reactivepowerlimits(value::TechHydro) = value.reactivepowerlimits
 """Get TechHydro ramplimits."""

--- a/src/models/generated/TechRenewable.jl
+++ b/src/models/generated/TechRenewable.jl
@@ -5,18 +5,18 @@ This file is auto-generated. Do not edit.
 
 mutable struct TechRenewable <: PowerSystems.TechnicalParams
     rating::Float64  # Thermal limited MVA Power Output of the unit. &lt;= Capacity 
-    reactivepower::Float64
-    reactivepowerlimits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
+    primemover::Union{Nothing,PrimeMovers}  # PrimeMover Technology according to EIA 923
+    reactivepowerlimits::Union{Nothing, Min_Max}
     powerfactor::Float64
     internal::PowerSystems.PowerSystemInternal
 end
 
-function TechRenewable(rating, reactivepower, reactivepowerlimits, powerfactor, )
-    TechRenewable(rating, reactivepower, reactivepowerlimits, powerfactor, PowerSystemInternal())
+function TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, )
+    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, PowerSystemInternal())
 end
 
-function TechRenewable(; rating, reactivepower, reactivepowerlimits, powerfactor, )
-    TechRenewable(rating, reactivepower, reactivepowerlimits, powerfactor, )
+function TechRenewable(; rating, primemover, reactivepowerlimits, powerfactor, )
+    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -24,7 +24,7 @@ end
 function TechRenewable(::Nothing)
     TechRenewable(;
         rating=0.0,
-        reactivepower=0.0,
+        primemover=nothing,
         reactivepowerlimits=nothing,
         powerfactor=1.0,
     )
@@ -32,8 +32,8 @@ end
 
 """Get TechRenewable rating."""
 get_rating(value::TechRenewable) = value.rating
-"""Get TechRenewable reactivepower."""
-get_reactivepower(value::TechRenewable) = value.reactivepower
+"""Get TechRenewable primemover."""
+get_primemover(value::TechRenewable) = value.primemover
 """Get TechRenewable reactivepowerlimits."""
 get_reactivepowerlimits(value::TechRenewable) = value.reactivepowerlimits
 """Get TechRenewable powerfactor."""

--- a/src/models/generated/TechThermal.jl
+++ b/src/models/generated/TechThermal.jl
@@ -5,21 +5,21 @@ This file is auto-generated. Do not edit.
 """Data Structure for the technical parameters of thermal generation technologies."""
 mutable struct TechThermal <: PowerSystems.TechnicalParams
     rating::Float64  # Thermal limited MVA Power Output of the unit. &lt;= Capacity 
-    activepower::Float64
-    activepowerlimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    reactivepower::Float64
-    reactivepowerlimits::Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
+    primemover::Union{Nothing,PrimeMovers}  # PrimeMover Technology according to EIA 923
+    fuel::Union{Nothing,ThermalFuels}  # PrimeMover Technology according to EIA 923
+    activepowerlimits::Min_Max
+    reactivepowerlimits::Union{Nothing, Min_Max}
     ramplimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     timelimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     internal::PowerSystems.PowerSystemInternal
 end
 
-function TechThermal(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
-    TechThermal(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, PowerSystemInternal())
+function TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, PowerSystemInternal())
 end
 
-function TechThermal(; rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
-    TechThermal(rating, activepower, activepowerlimits, reactivepower, reactivepowerlimits, ramplimits, timelimits, )
+function TechThermal(; rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,9 +27,9 @@ end
 function TechThermal(::Nothing)
     TechThermal(;
         rating=0.0,
-        activepower=0.0,
+        primemover=nothing,
+        fuel=nothing,
         activepowerlimits=(min=0.0, max=0.0),
-        reactivepower=0.0,
         reactivepowerlimits=nothing,
         ramplimits=nothing,
         timelimits=nothing,
@@ -38,12 +38,12 @@ end
 
 """Get TechThermal rating."""
 get_rating(value::TechThermal) = value.rating
-"""Get TechThermal activepower."""
-get_activepower(value::TechThermal) = value.activepower
+"""Get TechThermal primemover."""
+get_primemover(value::TechThermal) = value.primemover
+"""Get TechThermal fuel."""
+get_fuel(value::TechThermal) = value.fuel
 """Get TechThermal activepowerlimits."""
 get_activepowerlimits(value::TechThermal) = value.activepowerlimits
-"""Get TechThermal reactivepower."""
-get_reactivepower(value::TechThermal) = value.reactivepower
 """Get TechThermal reactivepowerlimits."""
 get_reactivepowerlimits(value::TechThermal) = value.reactivepowerlimits
 """Get TechThermal ramplimits."""

--- a/src/models/generated/ThermalStandard.jl
+++ b/src/models/generated/ThermalStandard.jl
@@ -7,17 +7,19 @@ mutable struct ThermalStandard <: ThermalGen
     name::String
     available::Bool
     bus::Bus
+    activepower::Float64
+    reactivepower::Float64
     tech::Union{Nothing, TechThermal}  # [-1. -1]
     op_cost::ThreePartCost
     internal::PowerSystems.PowerSystemInternal
 end
 
-function ThermalStandard(name, available, bus, tech, op_cost, )
-    ThermalStandard(name, available, bus, tech, op_cost, PowerSystemInternal())
+function ThermalStandard(name, available, bus, activepower, reactivepower, tech, op_cost, )
+    ThermalStandard(name, available, bus, activepower, reactivepower, tech, op_cost, PowerSystemInternal())
 end
 
-function ThermalStandard(; name, available, bus, tech, op_cost, )
-    ThermalStandard(name, available, bus, tech, op_cost, )
+function ThermalStandard(; name, available, bus, activepower, reactivepower, tech, op_cost, )
+    ThermalStandard(name, available, bus, activepower, reactivepower, tech, op_cost, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -27,6 +29,8 @@ function ThermalStandard(::Nothing)
         name="init",
         available=false,
         bus=Bus(nothing),
+        activepower=0.0,
+        reactivepower=0.0,
         tech=TechThermal(nothing),
         op_cost=ThreePartCost(nothing),
     )
@@ -38,6 +42,10 @@ get_name(value::ThermalStandard) = value.name
 get_available(value::ThermalStandard) = value.available
 """Get ThermalStandard bus."""
 get_bus(value::ThermalStandard) = value.bus
+"""Get ThermalStandard activepower."""
+get_activepower(value::ThermalStandard) = value.activepower
+"""Get ThermalStandard reactivepower."""
+get_reactivepower(value::ThermalStandard) = value.reactivepower
 """Get ThermalStandard tech."""
 get_tech(value::ThermalStandard) = value.tech
 """Get ThermalStandard op_cost."""

--- a/src/models/generated/Transformer2W.jl
+++ b/src/models/generated/Transformer2W.jl
@@ -6,6 +6,8 @@ This file is auto-generated. Do not edit.
 mutable struct Transformer2W <: ACBranch
     name::String
     available::Bool
+    activepower_flow::Float64
+    reactivepower_flow::Float64
     arch::Arch
     r::Float64
     x::Float64
@@ -14,12 +16,12 @@ mutable struct Transformer2W <: ACBranch
     internal::PowerSystems.PowerSystemInternal
 end
 
-function Transformer2W(name, available, arch, r, x, primaryshunt, rate, )
-    Transformer2W(name, available, arch, r, x, primaryshunt, rate, PowerSystemInternal())
+function Transformer2W(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, rate, )
+    Transformer2W(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, rate, PowerSystemInternal())
 end
 
-function Transformer2W(; name, available, arch, r, x, primaryshunt, rate, )
-    Transformer2W(name, available, arch, r, x, primaryshunt, rate, )
+function Transformer2W(; name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, rate, )
+    Transformer2W(name, available, activepower_flow, reactivepower_flow, arch, r, x, primaryshunt, rate, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -28,6 +30,8 @@ function Transformer2W(::Nothing)
     Transformer2W(;
         name="init",
         available=false,
+        activepower_flow=0.0,
+        reactivepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         r=0.0,
         x=0.0,
@@ -40,6 +44,10 @@ end
 get_name(value::Transformer2W) = value.name
 """Get Transformer2W available."""
 get_available(value::Transformer2W) = value.available
+"""Get Transformer2W activepower_flow."""
+get_activepower_flow(value::Transformer2W) = value.activepower_flow
+"""Get Transformer2W reactivepower_flow."""
+get_reactivepower_flow(value::Transformer2W) = value.reactivepower_flow
 """Get Transformer2W arch."""
 get_arch(value::Transformer2W) = value.arch
 """Get Transformer2W r."""

--- a/src/models/generated/VSCDCLine.jl
+++ b/src/models/generated/VSCDCLine.jl
@@ -6,22 +6,23 @@ This file is auto-generated. Do not edit.
 mutable struct VSCDCLine <: DCBranch
     name::String
     available::Bool
+    activepower_flow::Float64
     arch::Arch
-    rectifier_taplimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    rectifier_taplimits::Min_Max
     rectifier_xrc::Float64
-    rectifier_firingangle::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
-    inverter_taplimits::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    rectifier_firingangle::Min_Max
+    inverter_taplimits::Min_Max
     inverter_xrc::Float64
-    inverter_firingangle::NamedTuple{(:min, :max), Tuple{Float64, Float64}}
+    inverter_firingangle::Min_Max
     internal::PowerSystems.PowerSystemInternal
 end
 
-function VSCDCLine(name, available, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
-    VSCDCLine(name, available, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, PowerSystemInternal())
+function VSCDCLine(name, available, activepower_flow, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
+    VSCDCLine(name, available, activepower_flow, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, PowerSystemInternal())
 end
 
-function VSCDCLine(; name, available, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
-    VSCDCLine(name, available, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
+function VSCDCLine(; name, available, activepower_flow, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
+    VSCDCLine(name, available, activepower_flow, arch, rectifier_taplimits, rectifier_xrc, rectifier_firingangle, inverter_taplimits, inverter_xrc, inverter_firingangle, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -30,6 +31,7 @@ function VSCDCLine(::Nothing)
     VSCDCLine(;
         name="init",
         available=false,
+        activepower_flow=0.0,
         arch=Arch(Bus(nothing), Bus(nothing)),
         rectifier_taplimits=(min=0.0, max=0.0),
         rectifier_xrc=0.0,
@@ -44,6 +46,8 @@ end
 get_name(value::VSCDCLine) = value.name
 """Get VSCDCLine available."""
 get_available(value::VSCDCLine) = value.available
+"""Get VSCDCLine activepower_flow."""
+get_activepower_flow(value::VSCDCLine) = value.activepower_flow
 """Get VSCDCLine arch."""
 get_arch(value::VSCDCLine) = value.arch
 """Get VSCDCLine rectifier_taplimits."""


### PR DESCRIPTION
This PR addresses item #7 in #206. 
- Adds PrimeMover to generators and storage. Validation might be needed such that values make sense e.g., not assign CombinedCycle to Hydro. 
- Add Active Power and Flows to the devices. Looking forward to enabling PowerFlow initialization. Also, initial values are not technical parameters. 
- Minor name changes. 

Mappings for the Fuels are not implemented yet. 

This will break the parsing, cc. @daniel-thom. 