### PR TITLE
fix summary() and printing for current version

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -797,39 +797,6 @@ function get_components(
     return iter
 end
 
-"""Shows the component types and counts in a table."""
-function Base.summary(io::IO, sys::System)
-    println(io, "System")
-    println(io, "======")
-    println(io, "Base Power: $(sys.basepower)\n")
-
-    Base.summary(io, sys.components)
-    println(io, "\n")
-    Base.summary(io, sys.forecasts)
-end
-
-function Base.summary(io::IO, components::Components)
-    counts = Dict{String, Int}()
-    rows = []
-
-    for (subtype, values) in components
-        type_str = strip_module_names(string(subtype))
-        counts[type_str] = length(values)
-        parents = [strip_module_names(string(x)) for x in supertypes(subtype)]
-        row = (ConcreteType=type_str,
-               SuperTypes=join(parents, " <: "),
-               Count=length(values))
-        push!(rows, row)
-    end
-
-    sort!(rows, by = x -> x.ConcreteType)
-
-    df = DataFrames.DataFrame(rows)
-    println(io, "Components")
-    println(io, "==========")
-    Base.show(io, df)
-end
-
 function compare_values(x::System, y::System)::Bool
     match = true
     for key in keys(x.components)

--- a/src/models/forecasts.jl
+++ b/src/models/forecasts.jl
@@ -171,42 +171,6 @@ function SystemForecasts(data::NamedTuple)
     return SystemForecasts(ForecastsByType(), initial_time, resolution, horizon, interval)
 end
 
-function Base.summary(io::IO, forecasts::SystemForecasts)
-    counts = Dict{String, Int}()
-    rows = []
-
-    println(io, "Forecasts")
-    println(io, "=========")
-    println(io, "Resolution: $(forecasts.resolution)")
-    println(io, "Horizon: $(forecasts.horizon)")
-    println(io, "Interval: $(forecasts.interval)\n")
-    println(io, "---------------------------------")
-    initial_times = _get_forecast_initial_times(forecasts.data)
-    for initial_time in initial_times
-        for (key, values) in forecasts.data
-            if key.initial_time != initial_time
-                continue
-            end
-
-            type_str = strip_module_names(string(key.forecast_type))
-            counts[type_str] = length(values)
-            parents = [strip_module_names(string(x)) for x in supertypes(key.forecast_type)]
-            row = (ConcreteType=type_str,
-                   SuperTypes=join(parents, " <: "),
-                   Count=length(values))
-            push!(rows, row)
-        end
-        println(io, "Initial Time: $initial_time")
-        println(io, "---------------------------------")
-
-        sort!(rows, by = x -> x.ConcreteType)
-
-        df = DataFrames.DataFrame(rows)
-        Base.show(io, df)
-        println(io, "\n")
-    end
-end
-
 function JSON2.write(io::IO, system_forecasts::SystemForecasts)
     return JSON2.write(io, encode_for_json(system_forecasts))
 end

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -1,11 +1,11 @@
 # "smart" summary and REPL printing
 
 # Generic print for power system components (a new type that includes generation
-# technology types). The long version simply prints every field of the
+# technology types). The multi-line version simply prints every field of the
 # device. Tailored versions can be made for specific devices, if/when
 # desired. JJS 11/15/18
-function printPST(pst::Component, short = false, io::IO = stdout)
-    if short
+function printPST(pst::Component, singleline = false, io::IO = stdout)
+    if singleline
         pst_summary = Base.summary(pst)
         # objects of type TechnicalParams do not have a 'name' field
         if in(:name, fieldnames(typeof(pst)))
@@ -35,32 +35,121 @@ Base.show(io::IO, pst::Component) = printPST(pst, true, io)
 Base.show(io::IO, ::MIME"text/plain", pst::Component) = printPST(pst, false, io)
 
 
-# TODO consider supporting System
-# print function for System type
-#function printPowerSystem(system::_System, short = false,
-#                  io::IO = stdout)
-#    if short
-#        print(io, Base.summary(system))
-#    else
-#        print(io, "System:")
-#        fnames = fieldnames(typeof(system))
-#        for i = 1:nfields(fnames)
-#            fname = fnames[i]
-#            thefield = getfield(system, i)
-#            if thefield==nothing
-#                print(io, "\n   ", fname, ": nothing")
-#            elseif fname==:generators
-#                # print out long version for generators
-#                print(io, "\n   ", fname, ": \n     ")
-#                printPST(system.generators, false, io)
-#                print(io, "\n     (end generators)")
-#            else
-#                print(io, "\n   ", fname, ": ", thefield)
-#            end
-#        end
-#    end
-#end
-#Base.show(io::IO, system::_System) = printPowerSystem(system, true, io)
-#Base.show(io::IO, ::MIME"text/plain", system::_System) =
-#    printPowerSystem(system, false, io)
+# summary, print, repl show for sys.components
+function summaryComponents(components::Components)
+    strvar = repr(keys(components))
+    return replace(strvar, "DataType" => "System.Components")
+end
+Base.summary(components::Components) = summaryComponents(components::Components)
 
+function printComponents(components::Components, singleline = false, io::IO = stdout)
+    if singleline
+        # placeholder, just prints the summary -- can change to something more as needed
+        print(io, Base.summary(components))
+    else
+        counts = Dict{String, Int}()
+        rows = []
+
+        for (subtype, values) in components
+            type_str = strip_module_names(string(subtype))
+            counts[type_str] = length(values)
+            parents = [strip_module_names(string(x)) for x in supertypes(subtype)]
+            row = (ConcreteType=type_str,
+                   SuperTypes=join(parents, " <: "),
+                   Count=length(values))
+            push!(rows, row)
+        end
+
+        sort!(rows, by = x -> x.ConcreteType)
+
+        df = DataFrames.DataFrame(rows)
+        println(io, "Components")
+        println(io, "==========")
+        Base.show(io, df)
+    end
+end
+# uncomment this line to overload print() to use "singleline" version above
+#Base.show(io::IO, components::Components) = printComponents(components, true, io)
+Base.show(io::IO, ::MIME"text/plain", components::Components) = printComponents(components,
+                                                                                false, io)
+
+# summary, print, repl show for sys.components
+function summaryForecasts(forecasts::SystemForecasts)
+    return "SystemForecasts(res: $(forecasts.resolution), hzn:$(forecasts.horizon), int: $(forecasts.interval))"
+end
+Base.summary(forecasts::SystemForecasts) = summaryForecasts(forecasts::SystemForecasts)
+
+function printForecasts(forecasts::SystemForecasts, singleline = false, io::IO = stdout)
+    if singleline
+        # placeholder, just prints the summary -- can change to something more as needed
+        print(io, Base.summary(forecasts)) 
+    else
+        counts = Dict{String, Int}()
+        rows = []
+
+        println(io, "Forecasts")
+        println(io, "=========")
+        println(io, "Resolution: $(forecasts.resolution)")
+        println(io, "Horizon: $(forecasts.horizon)")
+        println(io, "Interval: $(forecasts.interval)\n")
+        println(io, "---------------------------------")
+        initial_times = _get_forecast_initial_times(forecasts.data)
+        for initial_time in initial_times
+            for (key, values) in forecasts.data
+                if key.initial_time != initial_time
+                    continue
+                end
+
+                type_str = strip_module_names(string(key.forecast_type))
+                counts[type_str] = length(values)
+                parents = [strip_module_names(string(x)) for x in supertypes(key.forecast_type)]
+                row = (ConcreteType=type_str,
+                       SuperTypes=join(parents, " <: "),
+                       Count=length(values))
+                push!(rows, row)
+            end
+            println(io, "Initial Time: $initial_time")
+            println(io, "---------------------------------")
+
+            sort!(rows, by = x -> x.ConcreteType)
+
+            df = DataFrames.DataFrame(rows)
+            Base.show(io, df)
+            println(io, "\n")
+        end
+    end
+end
+# uncomment this line to overload print() to use "singleline" version above
+#Base.show(io::IO, forecasts::SystemForecasts) = printForecasts(forecasts, true, io)
+Base.show(io::IO, ::MIME"text/plain", forecasts::SystemForecasts) = printForecasts(forecasts,
+                                                                                   false, io)
+
+# summary, print, repl show for sys.components
+function summarySystem(sys::System)
+    return "System(basepower: $(sys.basepower))"
+end
+Base.summary(sys::System) = summarySystem(sys::System)
+
+"""Shows the component types and counts in a table (for singleline=false) or a single-line
+summary (for singleline=true)."""
+function printSystem(sys::System, singleline = false, io::IO = stdout)
+    if singleline
+        print( io, "System(basepow: $(sys.basepower), "*Base.summary(sys.components)*", "
+              *Base.summary(sys.forecasts)*")" )
+    else
+        println(io, "System")
+        println(io, "======")
+        println(io, "Base Power: $(sys.basepower)\n")
+
+        printComponents(sys.components, singleline, io)
+        println(io, "\n")
+        printForecasts(sys.forecasts, singleline, io)
+    end
+end
+# uncomment this line to overload print() to use "singleline" version above
+#Base.show(io::IO, sys::System) = printSystem(sys, true, io)
+Base.show(io::IO, ::MIME"text/plain", sys::System) = printSystem(sys, false, io)
+
+
+#### also Base.summary() functions exist in utils/network_calculations/common.jl, but I did
+#### not modify those, JJS 9/12/19


### PR DESCRIPTION
Some work to revamp `summary()` and printing (`print()` and repl output) for System, SystemCompoenents, and SystemForecasts. This to address #325.

I am not up-to-date with the current structure of PowerSystem objects, and so I leave it to others revise this code further to output what is desired for `summary()` and `print()`. Currently, `print()` does the default thing from Base. To use the custom output, uncomment the "Base.show..." lines as called out.

Note that there are also `Base.summary()` methods in utils/network_calculations/common.jl for PowerNetworkMatrix, but I did not modify those. It looks like that code was copied from elsewhere and may be OK as is.