### PR TITLE
Simplify printing for PowerSystemTableData

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -29,3 +29,21 @@ end
 function Base.summary(arc::Arc)
     return "$(get_name(get_from(arc))) -> $(get_name(get_to(arc))): ($(typeof(arc)))"
 end
+
+function Base.show(io::IO, ::MIME"text/plain", data::PowerSystemTableData)
+    println(io, "$(typeof(data)):")
+    println(io, "  directory:  $(data.directory)")
+    if !isnothing(data.timeseries_metadata_file)
+        println(io, "  timeseries_metadata_file:  $(data.timeseries_metadata_file)")
+    end
+    println(io, "  basepower:  $(data.basepower)")
+    for field in ("branch", "bus", "dcline", "gen", "load", "services")
+        print(io, "  $field:  ")
+        val = getfield(data, Symbol(field))
+        if isnothing(val)
+            println(io, "no data")
+        else
+            println(io, "$(summary(val))")
+        end
+    end
+end


### PR DESCRIPTION
I think this you asked for something like this yesterday, but I may have forgotten a few things.

```
julia> rts_data
PowerSystems.PowerSystemTableData:
  directory:  ../RTS-GMLC/RTS_Data/SourceData
  timeseries_metadata_file:  ../RTS-GMLC/RTS_Data/SourceData/timeseries_pointers.csv
  basepower:  100.0
  branch:  120×14 DataFrames.DataFrame
  bus:  73×15 DataFrames.DataFrame
  dcline:  1×60 DataFrames.DataFrame
  gen:  158×57 DataFrames.DataFrame
  load:  no data
  services:  7×5 DataFrames.DataFrame
```