### PR TITLE
Change forecast labels to component accessor functions

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -2,37 +2,36 @@
 const SKIP_PM_VALIDATION = false
 
 """
-    System
+System
 
-    A power system defined by fields for basepower, components, and forecasts.
+A power system defined by fields for basepower, components, and forecasts.
 
-    # Constructor
-    ```julia
-    System(basepower)
-    System(components, basepower)
-    System(buses, generators, loads, branches, storage, basepower, services, annex; kwargs...)
-    System(buses, generators, loads, basepower; kwargs...)
-    System(file; kwargs...)
-    System(; buses, generators, loads, branches, storage, basepower, services, annex, kwargs...)
-    System(; kwargs...)
-    ```
+```julia
+System(basepower)
+System(components, basepower)
+System(buses, generators, loads, branches, storage, basepower, services, annex; kwargs...)
+System(buses, generators, loads, basepower; kwargs...)
+System(file; kwargs...)
+System(; buses, generators, loads, branches, storage, basepower, services, annex, kwargs...)
+System(; kwargs...)
+```
 
-    # Arguments
+# Arguments
+- `buses::Vector{Bus}`: an array of buses
+- `generators::Vector{Generator}`: an array of generators of (possibly) different types
+- `loads::Vector{ElectricLoad}`: an array of load specifications that includes timing of the loads
+- `branches::Union{Nothing, Vector{Branch}}`: an array of branches; may be `nothing`
+- `storage::Union{Nothing, Vector{Storage}}`: an array of storage devices; may be `nothing`
+- `basepower::Float64`: the base power value for the system
+- `services::Union{Nothing, Vector{ <: Service}}`: an array of services; may be `nothing`
 
-    * `buses`::Vector{Bus} : an array of buses
-    * `generators`::Vector{Generator} : an array of generators of (possibly) different types
-    * `loads`::Vector{ElectricLoad} : an array of load specifications that includes timing of the loads
-    * `branches`::Union{Nothing, Vector{Branch}} : an array of branches; may be `nothing`
-    * `storage`::Union{Nothing, Vector{Storage}} : an array of storage devices; may be `nothing`
-    * `basepower`::Float64 : the base power value for the system
-    * `services`::Union{Nothing, Vector{ <: Service}} : an array of services; may be `nothing`
+# Keyword arguments
+- `runchecks::Bool`: Run available checks on input fields and when add_component! is called.
+  Throws InvalidRange if an error is found.
+- `time_series_in_memory::Bool=false`: Store time series data in memory instead of HDF5.
+- `configpath::String`: specify path to validation config file
 
-    # Keyword arguments
 
-    * `runchecks`::Bool : run available checks on input fields. If an error is found in a field, that component will not be added to the system and InvalidRange is thrown.
-    * `time_series_in_memory`::Bool=false : Store time series data in memory instead of HDF5
-    * `configpath`::String : specify path to validation config file
-    DOCTODO: any other keyword arguments? genmap_file, REGEX_FILE
 """
 struct System <: PowerSystemType
     data::IS.SystemData

--- a/src/base.jl
+++ b/src/base.jl
@@ -229,7 +229,6 @@ end
     add_forecasts!(
                    sys::System,
                    metadata_file::AbstractString,
-                   label_mapping::Dict{Tuple{String, String}, String};
                    resolution=nothing,
                   )
 
@@ -239,18 +238,14 @@ Adds forecasts from a metadata file or metadata descriptors.
 - `sys::System`: system
 - `metadata_file::AbstractString`: metadata file for timeseries
   that includes an array of IS.TimeseriesFileMetadata instances or a vector.
-- `label_mapping::Dict{Tuple{String, String}, String}`: maps customized component field names to
-  PowerSystem field names
 - `resolution::DateTime.Period=nothing`: skip forecast that don't match this resolution.
 """
 function add_forecasts!(
                         sys::System,
-                        metadata_file::AbstractString,
-                        label_mapping::Dict{Tuple{String, String}, String};
+                        metadata_file::AbstractString;
                         resolution=nothing,
                        )
-    return IS.add_forecasts!(Component, sys.data, metadata_file, label_mapping;
-                             resolution=resolution)
+    return IS.add_forecasts!(Component, sys.data, metadata_file; resolution=resolution)
 end
 
 """
@@ -269,7 +264,7 @@ Adds forecasts from a metadata file or metadata descriptors.
 """
 function add_forecasts!(
                         sys::System,
-                        timeseries_metadata::Vector{IS.TimeseriesFileMetadata},
+                        timeseries_metadata::Vector{IS.TimeseriesFileMetadata};
                         resolution=nothing
                        )
     return IS.add_forecasts!(Component, sys.data, timeseries_metadata;
@@ -650,7 +645,7 @@ Return a TimeSeries.TimeArray where the forecast data has been multiplied by the
 component field.
 """
 function get_forecast_values(component::Component, forecast::Forecast)
-    return IS.get_forecast_values(component, forecast)
+    return IS.get_forecast_values(PowerSystems, component, forecast)
 end
 
 """

--- a/src/base.jl
+++ b/src/base.jl
@@ -30,6 +30,7 @@ const SKIP_PM_VALIDATION = false
     # Keyword arguments
 
     * `runchecks`::Bool : run available checks on input fields. If an error is found in a field, that component will not be added to the system and InvalidRange is thrown.
+    * `time_series_in_memory`::Bool=false : Store time series data in memory instead of HDF5
     * `configpath`::String : specify path to validation config file
     DOCTODO: any other keyword arguments? genmap_file, REGEX_FILE
 """
@@ -1040,12 +1041,14 @@ end
 function _create_system_data_from_kwargs(; kwargs...)
     validation_descriptor_file = nothing
     runchecks = get(kwargs, :runchecks, true)
+    time_series_in_memory = get(kwargs, :time_series_in_memory, false)
     if runchecks
         validation_descriptor_file = get(kwargs, :configpath,
                                          POWER_SYSTEM_STRUCT_DESCRIPTOR_FILE)
     end
 
-    return IS.SystemData(; validation_descriptor_file=validation_descriptor_file)
+    return IS.SystemData(; validation_descriptor_file=validation_descriptor_file,
+                         time_series_in_memory=time_series_in_memory)
 end
 
 function parse_types(mod)

--- a/src/descriptors/power_system_structs.json
+++ b/src/descriptors/power_system_structs.json
@@ -112,12 +112,6 @@
         "validation_action": "error"
       },
       {
-        "name": "_forecasts",
-        "null_value": "InfrastructureSystems.Forecasts()",
-        "data_type": "InfrastructureSystems.Forecasts",
-        "default": "InfrastructureSystems.Forecasts()"
-      },
-      {
         "name": "internal",
         "data_type": "InfrastructureSystemsInternal"
       }
@@ -152,12 +146,6 @@
         "data_type": "Float64",
         "valid_range": {"min":0.0, "max":1.0},
         "validation_action": "error"
-      },
-      {
-        "name": "_forecasts",
-        "null_value": "InfrastructureSystems.Forecasts()",
-        "data_type": "InfrastructureSystems.Forecasts",
-        "default": "InfrastructureSystems.Forecasts()"
       },
       {
         "name": "internal",
@@ -213,12 +201,6 @@
         "data_type": "Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}",
         "valid_range": {"min":0.0, "max":null},
         "validation_action": "error"
-      },
-      {
-        "name": "_forecasts",
-        "null_value": "InfrastructureSystems.Forecasts()",
-        "data_type": "InfrastructureSystems.Forecasts",
-        "default": "InfrastructureSystems.Forecasts()"
       },
       {
         "name": "internal",

--- a/src/models/generated/TechHydro.jl
+++ b/src/models/generated/TechHydro.jl
@@ -10,16 +10,15 @@ mutable struct TechHydro <: TechnicalParams
     reactivepowerlimits::Union{Nothing, Min_Max}
     ramplimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     timelimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
-    _forecasts::InfrastructureSystems.Forecasts
     internal::InfrastructureSystemsInternal
 end
 
-function TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts, InfrastructureSystemsInternal())
+function TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, InfrastructureSystemsInternal())
 end
 
-function TechHydro(; rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts, )
+function TechHydro(; rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechHydro(rating, primemover, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -32,7 +31,6 @@ function TechHydro(::Nothing)
         reactivepowerlimits=nothing,
         ramplimits=nothing,
         timelimits=nothing,
-        _forecasts=InfrastructureSystems.Forecasts(),
     )
 end
 
@@ -48,7 +46,5 @@ get_reactivepowerlimits(value::TechHydro) = value.reactivepowerlimits
 get_ramplimits(value::TechHydro) = value.ramplimits
 """Get TechHydro timelimits."""
 get_timelimits(value::TechHydro) = value.timelimits
-"""Get TechHydro _forecasts."""
-get__forecasts(value::TechHydro) = value._forecasts
 """Get TechHydro internal."""
 get_internal(value::TechHydro) = value.internal

--- a/src/models/generated/TechRenewable.jl
+++ b/src/models/generated/TechRenewable.jl
@@ -8,16 +8,15 @@ mutable struct TechRenewable <: TechnicalParams
     primemover::PrimeMovers  # PrimeMover Technology according to EIA 923
     reactivepowerlimits::Union{Nothing, Min_Max}
     powerfactor::Float64
-    _forecasts::InfrastructureSystems.Forecasts
     internal::InfrastructureSystemsInternal
 end
 
-function TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, _forecasts, InfrastructureSystemsInternal())
+function TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, )
+    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, InfrastructureSystemsInternal())
 end
 
-function TechRenewable(; rating, primemover, reactivepowerlimits, powerfactor, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, _forecasts, )
+function TechRenewable(; rating, primemover, reactivepowerlimits, powerfactor, )
+    TechRenewable(rating, primemover, reactivepowerlimits, powerfactor, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -28,7 +27,6 @@ function TechRenewable(::Nothing)
         primemover=OT::PrimeMovers,
         reactivepowerlimits=nothing,
         powerfactor=1.0,
-        _forecasts=InfrastructureSystems.Forecasts(),
     )
 end
 
@@ -40,7 +38,5 @@ get_primemover(value::TechRenewable) = value.primemover
 get_reactivepowerlimits(value::TechRenewable) = value.reactivepowerlimits
 """Get TechRenewable powerfactor."""
 get_powerfactor(value::TechRenewable) = value.powerfactor
-"""Get TechRenewable _forecasts."""
-get__forecasts(value::TechRenewable) = value._forecasts
 """Get TechRenewable internal."""
 get_internal(value::TechRenewable) = value.internal

--- a/src/models/generated/TechThermal.jl
+++ b/src/models/generated/TechThermal.jl
@@ -11,16 +11,15 @@ mutable struct TechThermal <: TechnicalParams
     reactivepowerlimits::Union{Nothing, Min_Max}
     ramplimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
     timelimits::Union{Nothing, NamedTuple{(:up, :down), Tuple{Float64, Float64}}}
-    _forecasts::InfrastructureSystems.Forecasts
     internal::InfrastructureSystemsInternal
 end
 
-function TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts, InfrastructureSystemsInternal())
+function TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, InfrastructureSystemsInternal())
 end
 
-function TechThermal(; rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts=InfrastructureSystems.Forecasts(), )
-    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, _forecasts, )
+function TechThermal(; rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
+    TechThermal(rating, primemover, fuel, activepowerlimits, reactivepowerlimits, ramplimits, timelimits, )
 end
 
 # Constructor for demo purposes; non-functional.
@@ -34,7 +33,6 @@ function TechThermal(::Nothing)
         reactivepowerlimits=nothing,
         ramplimits=nothing,
         timelimits=nothing,
-        _forecasts=InfrastructureSystems.Forecasts(),
     )
 end
 
@@ -52,7 +50,5 @@ get_reactivepowerlimits(value::TechThermal) = value.reactivepowerlimits
 get_ramplimits(value::TechThermal) = value.ramplimits
 """Get TechThermal timelimits."""
 get_timelimits(value::TechThermal) = value.timelimits
-"""Get TechThermal _forecasts."""
-get__forecasts(value::TechThermal) = value._forecasts
 """Get TechThermal internal."""
 get_internal(value::TechThermal) = value.internal

--- a/src/models/generated/VSCDCLine.jl
+++ b/src/models/generated/VSCDCLine.jl
@@ -2,7 +2,7 @@
 This file is auto-generated. Do not edit.
 =#
 
-"""As implemented in Milano&#39;s Book, Page 397"""
+"""As implemented in Milano's Book, Page 397"""
 mutable struct VSCDCLine <: DCBranch
     name::String
     available::Bool

--- a/src/models/generation.jl
+++ b/src/models/generation.jl
@@ -13,3 +13,6 @@ function IS.get_limits(valid_range::Union{NamedTuple{(:min,:max)}, NamedTuple{(:
     return (min = valid_range.min, max = valid_range.max, zero = 0.0)
 end
 
+get_rating(gen::Generator) = get_rating(get_tech(gen))
+get_active_power_limits_min(gen::Generator) = get_activepowerlimits(get_tech(gen)).min
+get_active_power_limits_max(gen::Generator) = get_activepowerlimits(get_tech(gen)).max

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -242,14 +242,19 @@ Construct a System from PowerSystemTableData data.
 # Arguments
 - `forecast_resolution::Union{DateTime, Nothing}=nothing`: only store forecasts that match
   this resolution.
+- `time_series_in_memory::Bool=false`: Store time series data in memory instead of HDF5 file
 
 Throws DataFormatError if forecasts with multiple resolutions are detected.
 - A forecast has a different resolution than others.
 - A forecast has a different horizon than others.
 
 """
-function System(data::PowerSystemTableData; forecast_resolution=nothing)
-    sys = System(data.basepower)
+function System(
+                data::PowerSystemTableData;
+                forecast_resolution=nothing,
+                time_series_in_memory=false,
+               )
+    sys = System(data.basepower; time_series_in_memory=time_series_in_memory)
 
     bus_csv_parser!(sys, data)
     loadzone_csv_parser!(sys, data)

--- a/src/parsers/power_system_table_data.jl
+++ b/src/parsers/power_system_table_data.jl
@@ -270,9 +270,7 @@ function System(data::PowerSystemTableData; forecast_resolution=nothing)
     end
 
     if !isnothing(data.timeseries_metadata_file)
-        label_mapping = _create_forecast_label_mapping(data.user_descriptors)
-        add_forecasts!(sys, data.timeseries_metadata_file, label_mapping;
-                       resolution=forecast_resolution)
+        add_forecasts!(sys, data.timeseries_metadata_file; resolution=forecast_resolution)
     end
 
     check!(sys)
@@ -970,26 +968,4 @@ function _read_data_row(data::PowerSystemTableData, row, field_infos; na_to_noth
     end
 
     return NamedTuple{Tuple(Symbol.(fields))}(vals)
-end
-
-"""
-Forecasts are created for specific fields of a component. The field name in the metadata
-file may be customized, so this creates a mapping of (category, custom_name) to name.
-"""
-function _create_forecast_label_mapping(user_descriptors::Dict)
-    mapping = Dict{Tuple{String, String}, String}()
-    for (category, params) in user_descriptors
-        fields = [d["name"] for d in params]
-        ufields = unique(fields)
-        counts=[(i, count(x->x==i, fields)) for i in ufields if count(x->x==i, fields)>1] # finding duplicated targets
-        if length(counts) > 0
-            throw(DataFormatError("$POWER_SYSTEM_DESCRIPTOR_FILE has multiple entries for $(counts[1]) in $category"))
-        end
-        for param in params
-            key = (lowercase(string(category)), param["custom_name"])
-            mapping[key] = param["name"]
-        end
-    end
-
-    return mapping
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ const PSY = PowerSystems
 
 include(joinpath(@__DIR__, "../src/utils/data.jl"))
 import .UtilsData: TestData
-download(TestData; branch = "master")
+download(TestData; branch = "tech-parameter-forecasts")
 
 BASE_DIR = abspath(joinpath(dirname(Base.find_package("PowerSystems")), ".."))
 DATA_DIR = joinpath(BASE_DIR, "data")

--- a/test/test_system.jl
+++ b/test/test_system.jl
@@ -47,8 +47,7 @@
     components = collect(get_components(HydroDispatch, sys))
     @test !isempty(components)
     component = components[1]
-    forecast = get_forecast(Deterministic, component, initial_time,
-                            "rating")
+    forecast = get_forecast(Deterministic, component, initial_time, "get_rating")
     @test forecast isa Deterministic
 
     horizon = get_forecasts_horizon(sys)


### PR DESCRIPTION
There is one thing not done here:  When calling add_forecast there is no validation that the label translates to a function that is callable on the component.  I'll wait to do that until you guys take a first pass on the implementation.

Note that it would be trivial to change label from accessor function to fields.

Also note that I DID create a branch in PowerSystemsTestData in support of these changes but NOT the RTS_GMLC repo.