### PR TITLE
Extended hr cols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.6.2
 
+- Downgrade compatible version of CSV to 0.5.13 to avoid tab complete hang.
+
+## v0.6.2
+
 - Bug Fix in docstrings autogeneration code
 - Contigous forecasts function added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerSystems"
 uuid = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 authors = ["Jose Daniel Lara", "Dheepak Krishnamurthy", "Clayton Barrows", "Daniel Thom"]
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
@@ -19,7 +19,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-CSV = "~0.5"
+CSV = "= 0.5.13"
 DataFrames = "~0.19"
 InfrastructureSystems = "~0.4"
 JSON = "~0.21"

--- a/src/descriptors/power_system_inputs.json
+++ b/src/descriptors/power_system_inputs.json
@@ -294,6 +294,37 @@
             "description": "Heat rate Incremental 4 TODO"
         },
         {
+            "name": "heat_rate_incr_5",
+            "description": "Heat rate Incremental 5 TODO"
+        },
+        {
+            "name": "heat_rate_incr_6",
+            "description": "Heat rate Incremental 6 TODO"
+        },
+        {
+            "name": "heat_rate_incr_7",
+            "description": "Heat rate Incremental 7 TODO"
+        },
+        {
+            "name": "heat_rate_incr_8",
+            "description": "Heat rate Incremental 8 TODO"
+        },
+        {
+            "name": "heat_rate_incr_9",
+            "description": "Heat rate Incremental 9 TODO"
+        },      {
+            "name": "heat_rate_incr_10",
+            "description": "Heat rate Incremental 10 TODO"
+        },
+        {
+            "name": "heat_rate_incr_11",
+            "description": "Heat rate Incremental 11 TODO"
+        },
+        {
+            "name": "heat_rate_incr_12",
+            "description": "Heat rate Incremental 12 TODO"
+        },
+        {
             "unit": "%",
             "name": "output_percent_0",
             "description": "Output point 0 on heat rate curve as a percentage of PMax"
@@ -317,6 +348,44 @@
             "unit": "%",
             "name": "output_percent_4",
             "description": "Output point 4 on heat rate curve as a percentage of PMax"
+        },{
+            "unit": "%",
+            "name": "output_percent_5",
+            "description": "Output point 5 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_6",
+            "description": "Output point 6 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_7",
+            "description": "Output point 7 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_8",
+            "description": "Output point 8 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_9",
+            "description": "Output point 9 on heat rate curve as a percentage of PMax"
+        },{
+            "unit": "%",
+            "name": "output_percent_10",
+            "description": "Output point 10 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_11",
+            "description": "Output point 11 on heat rate curve as a percentage of PMax"
+        },
+        {
+            "unit": "%",
+            "name": "output_percent_12",
+            "description": "Output point 12 on heat rate curve as a percentage of PMax"
         },
         {
             "unit": "MVA",

--- a/src/models/supplemental_constructors.jl
+++ b/src/models/supplemental_constructors.jl
@@ -55,3 +55,10 @@ function Bus(number, name, bustype::String, angle, voltage, voltagelimits, basev
     return Bus(number, name, get_enum_value(BusType, bustype), angle, voltage,
                voltagelimits, basevoltage, InfrastructureSystemsInternal())
 end
+
+"""Allows construction of a reserve from an iterator."""
+function StaticReserve(name, contributingdevices::IS.FlattenIteratorWrapper,
+                       timeframe, requirement, _forecasts, InfrastructureSystemsInternal)
+    return StaticReserve(name, collect(contributingdevices),
+                  timeframe, requirement, _forecasts, InfrastructureSystemsInternal)
+end


### PR DESCRIPTION
- creates a superset of heat rate traunches to support parsing up to 13 point heat rate curves